### PR TITLE
ci: add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+# on:
+#   push:
+#     branches:
+#       - main
+#       - stage
+
+permissions: write-all
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install
+        run: npm install
+
+      - name: Build
+        run: npm run compile
+
+      - name: Release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  sync-stage:
+    needs: release
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+
+      - name: Merge main into stage
+        run: |
+          git fetch origin
+          git pull origin main
+          git checkout stage
+          git merge main --allow-unrelated-histories --no-edit -Xtheirs -m "Merge branch 'main' into stage [skip ci]"
+          git push origin stage

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,52 @@
+{
+  "branches": [
+    "main",
+    {
+      "name": "stage",
+      "prerelease": true,
+      "channel": "stage"
+    }
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "options": {
+          "preset": {
+            "name": "conventionalchangelog",
+            "issuePrefixes": [
+              "ISSUE-"
+            ],
+            "issueUrlFormat": "https://github.com/aziontech/lib/issues/{{id}}"
+          }
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "issuePrefixes": [
+            "ISSUE-"
+          ],
+          "issueUrlFormat": "https://github.com/aziontech/lib/issues/{{id}}"
+        }
+      }
+    ],
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "package.json",
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): ${nextRelease.version} \n\n[skip ci]\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
### Goal

This PR is to add the semantic release configuration file and also the workflow for the lib release.

`Important: The workflow is configured for workflow_dispatch, as soon as the lib is ready for deployment it is necessary to change it to the push trigger.`