### PR TITLE
feat: adding domain, origin and purge types in AzionConfig

### DIFF
--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -9,7 +9,7 @@ export type AzionConfig = {
     mtls?: {
       verification: 'enforce' | 'permissive';
       trustedCaCertificateId: number;
-      crlLis?: number[];
+      crlList?: number[];
     };
   };
 


### PR DESCRIPTION
Adding the types to `azion.config.js`:

- Domain
- Origin
- Purge

For the Origin types, the missing fields were added.