### PR TITLE
feat: updating function returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ const client = createClient({ token: 'your-api-token', debug: true });
 const newBucket = await client.storage.createBucket('my-new-bucket', 'public');
 console.log(`Bucket created with name: ${newBucket.name}`);
 
-const allBuckets = await client.storage.getBuckets();
-console.log(`Retrieved ${allBuckets.length} buckets`);
+const { data: allBuckets } = await client.storage.getBuckets();
+console.log(`Retrieved ${allBuckets.count} buckets`);
 
 // SQL
 const newDatabase = await client.sql.createDatabase('my-new-db');
@@ -74,7 +74,7 @@ console.log(`Purge successful: ${purgeResult.items}`);
 ```typescript
 import { createClient } from 'azion';
 import type { AzionClient, Bucket, Purge } from 'azion/client';
-import type { AzionDatabaseResponse, AzionDatabaseQueryResponse } from 'azion/sql';
+import type { AzionDatabaseResponse, AzionDatabaseQueryResponse, AzionListBuckets } from 'azion/sql';
 
 const client: AzionClient = createClient({ token: 'your-api-token', debug: true });
 
@@ -82,8 +82,8 @@ const client: AzionClient = createClient({ token: 'your-api-token', debug: true 
 const newBucket: Bucket | null = await client.storage.createBucket('my-new-bucket', 'public');
 console.log(`Bucket created with name: ${newBucket.name}`);
 
-const allBuckets: Bucket[] | null = await client.storage.getBuckets();
-console.log(`Retrieved ${allBuckets.length} buckets`);
+const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.storage.getBuckets();
+console.log(`Retrieved ${allBuckets.count} buckets`);
 
 // SQL
 const newDatabase: AzionDatabaseResponse = await client.sql.createDatabase('my-new-db');
@@ -110,14 +110,14 @@ import { createClient } from 'azion/storage';
 
 const client = createClient({ token: 'your-api-token', debug: true });
 
-const newBucket = await client.createBucket('my-new-bucket', 'public');
-if (newBucket) {
-  console.log(`Bucket created with name: ${newBucket.name}`);
+const { data, error } = await client.createBucket('my-new-bucket', 'public');
+if (data) {
+  console.log(`Bucket created with name: ${data.name}`);
 }
 
-const allBuckets = await client.getBuckets();
+const { data: allBuckets } = await client.getBuckets();
 if (allBuckets) {
-  console.log(`Retrieved ${allBuckets.length} buckets`);
+  console.log(`Retrieved ${allBuckets.count} buckets`);
 }
 ```
 
@@ -125,18 +125,18 @@ if (allBuckets) {
 
 ```typescript
 import { createClient } from 'azion/storage';
-import { StorageClient, Bucket } from 'azion/storage/types';
+import type { AzionStorageClient, AzionStorageResponse, AzionBucket, AzionListBuckets } from 'azion/storage';
 
-const client: StorageClient = createClient({ token: 'your-api-token', debug: true });
+const client: AzionStorageClient = createClient({ token: 'your-api-token', debug: true });
 
-const newBucket: Bucket | null = await client.createBucket('my-new-bucket', 'public');
-if (newBucket) {
-  console.log(`Bucket created with name: ${newBucket.name}`);
+const { data, error }: AzionStorageResponse<AzionBucket> = await client.createBucket('my-new-bucket', 'public');
+if (data) {
+  console.log(`Bucket created with name: ${data.name}`);
 }
 
-const allBuckets: Bucket[] | null = await client.getBuckets();
+const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.getBuckets();
 if (allBuckets) {
-  console.log(`Retrieved ${allBuckets.length} buckets`);
+  console.log(`Retrieved ${allBuckets.count} buckets`);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ console.log(`Purge successful: ${purgeResult.items}`);
 ```typescript
 import { createClient } from 'azion';
 import type { AzionClient, Bucket, Purge } from 'azion/client';
-import type { AzionDatabaseResponse, AzionDatabaseQueryResponse, AzionListBuckets } from 'azion/sql';
+import type { AzionDatabaseResponse, AzionDatabaseQueryResponse, AzionBuckets } from 'azion/sql';
 
 const client: AzionClient = createClient({ token: 'your-api-token', debug: true });
 
@@ -82,7 +82,7 @@ const client: AzionClient = createClient({ token: 'your-api-token', debug: true 
 const newBucket: Bucket | null = await client.storage.createBucket('my-new-bucket', 'public');
 console.log(`Bucket created with name: ${newBucket.name}`);
 
-const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.storage.getBuckets();
+const { data: allBuckets }: AzionStorageResponse<AzionBuckets> = await client.storage.getBuckets();
 console.log(`Retrieved ${allBuckets.count} buckets`);
 
 // SQL
@@ -125,7 +125,7 @@ if (allBuckets) {
 
 ```typescript
 import { createClient } from 'azion/storage';
-import type { AzionStorageClient, AzionStorageResponse, AzionBucket, AzionListBuckets } from 'azion/storage';
+import type { AzionStorageClient, AzionStorageResponse, AzionBucket, AzionBuckets } from 'azion/storage';
 
 const client: AzionStorageClient = createClient({ token: 'your-api-token', debug: true });
 
@@ -134,7 +134,7 @@ if (data) {
   console.log(`Bucket created with name: ${data.name}`);
 }
 
-const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.getBuckets();
+const { data: allBuckets }: AzionStorageResponse<AzionBuckets> = await client.getBuckets();
 if (allBuckets) {
   console.log(`Retrieved ${allBuckets.count} buckets`);
 }

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ const { data: allBuckets } = await client.storage.getBuckets();
 console.log(`Retrieved ${allBuckets.count} buckets`);
 
 // SQL
-const newDatabase = await client.sql.createDatabase('my-new-db');
-console.log(`Database created with ID: ${newDatabase.data.id}`);
+const { data: newDatabase } = await client.sql.createDatabase('my-new-db');
+console.log(`Database created with ID: ${newDatabase.id}`);
 
-const allDatabases = await client.sql.getDatabases();
-console.log(`Retrieved ${allDatabases.data.length} databases`);
+const { data: allDatabases } = await client.sql.getDatabases();
+console.log(`Retrieved ${allDatabases.count} databases`);
 
 // Purge
 const purgeResult = await client.purge.purgeURL(['http://example.com/image.jpg']);
@@ -86,11 +86,11 @@ const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await clien
 console.log(`Retrieved ${allBuckets.count} buckets`);
 
 // SQL
-const newDatabase: AzionDatabaseResponse = await client.sql.createDatabase('my-new-db');
-console.log(`Database created with ID: ${newDatabase.data.id}`);
+const { data: newDatabase }: AzionDatabaseResponse<AzionDatabase> = await client.sql.createDatabase('my-new-db');
+console.log(`Database created with ID: ${newDatabase.id}`);
 
-const allDatabases: AzionDatabaseResponse = await client.sql.getDatabases();
-console.log(`Retrieved ${allDatabases.data.length} databases`);
+const { data: allDatabases }: AzionDatabaseResponse<AzionDatabaseCollections> = await client.sql.getDatabases();
+console.log(`Retrieved ${allDatabases.count} databases`);
 
 // Purge
 const purgeResult: Purge | null = await client.purge.purgeURL(['http://example.com/image.jpg']);
@@ -179,9 +179,9 @@ if (data) {
   console.log(`Database created with ID: ${data.id}`);
 }
 
-const allDatabases: AzionDatabaseResponse = await client.getDatabases();
-if (allDatabases.data) {
-  console.log(`Retrieved ${allDatabases.data.length} databases`);
+const { data: allDatabases }: AzionDatabaseResponse = await client.getDatabases();
+if (allDatabases) {
+  console.log(`Retrieved ${allDatabases.count} databases`);
 }
 ```
 

--- a/packages/client/README.MD
+++ b/packages/client/README.MD
@@ -127,9 +127,9 @@ if (newDatabase) {
   console.log(`AzionDatabase created with ID: ${newDatabase.id}`);
 }
 
-const allDatabases = await client.sql.getDatabases();
-if (allDatabases?.data) {
-  console.log(`Retrieved ${allDatabases?.data?.length} databases`);
+const { data: allDatabases } = await client.sql.getDatabases();
+if (allDatabases) {
+  console.log(`Retrieved ${allDatabases?.count} databases`);
 }
 
 const queryResult = await client.sql.query('SELECT * FROM users');
@@ -147,19 +147,19 @@ import type { AzionDatabaseResponse, AzionDatabaseQueryResponse } from 'azion/sq
 
 const client: AzionClient = createClient({ token: 'your-api-token', { debug: true } });
 
-const { data: newDatabase, error }: AzionDatabaseResponse = await client.sql.createDatabase('my-new-db');
+const { data: newDatabase, error }: AzionDatabaseResponse<AzionDatabase> = await client.sql.createDatabase('my-new-db');
 if (newDatabase) {
   console.log(`AzionDatabase created with ID: ${newDatabase.id}`);
 }
 
-const allDatabases: AzionDatabaseResponse = await client.sql.getDatabases();
-if (allDatabases?.data) {
-  console.log(`Retrieved ${allDatabases?.data?.length} databases`);
+const { data: allDatabases }: AzionDatabaseResponse<AzionDatabaseCollections> = await client.sql.getDatabases();
+if (allDatabases) {
+  console.log(`Retrieved ${allDatabases?.count} databases`);
 }
 
-const queryResult: AzionDatabaseQueryResponse = await client.sql.query(['SELECT * FROM users']);
+const queryResult: AzionDatabaseResponse<AzionDatabaseQueryResponse> = await client.sql.query(['SELECT * FROM users']);
 if (queryResult?.data) {
-  console.log(`Query executed. Rows returned: ${queryResult?.data?.length}`);
+  console.log(`Query executed. Rows returned: ${queryResult?.data?.results.length}`);
 }
 ```
 

--- a/packages/client/README.MD
+++ b/packages/client/README.MD
@@ -172,17 +172,17 @@ import { createClient } from 'azion';
 
 const client = createClient({ token: 'your-api-token', { debug: true } });
 
-const purgeResult = await client.purge.purgeURL(['http://example.com/image.jpg']);
+const { data: purgeResult } = await client.purge.purgeURL(['http://example.com/image.jpg']);
 if (purgeResult) {
   console.log(`Purge successful: ${purgeResult.items}`);
 }
 
-const cacheKeyResult = await client.purge.purgeCacheKey(['my-cache-key-1', 'my-cache-key-2']);
+const { data: cacheKeyResult } = await client.purge.purgeCacheKey(['my-cache-key-1', 'my-cache-key-2']);
 if (cacheKeyResult) {
   console.log(`Cache key purge successful: ${cacheKeyResult.items}`);
 }
 
-const wildcardResult = await client.purge.purgeWildCard(['http://example.com/*']);
+const { data: wildcardResult } = await client.purge.purgeWildCard(['http://example.com/*']);
 if (wildcardResult) {
   console.log(`Wildcard purge successful: ${wildcardResult.items}`);
 }
@@ -192,21 +192,28 @@ if (wildcardResult) {
 
 ```typescript
 import { createClient } from 'azion';
-import { AzionClient, Purge } from 'azion/purge/types';
+import { AzionClient, AzionPurgeResponse, AzionPurge } from 'azion/purge/types';
 
 const client: AzionClient = createClient({ token: 'your-api-token', debug: true });
 
-const purgeResult: Purge | null = await client.purge.purgeURL(['http://example.com/image.jpg']);
+const { data: purgeResult }: AzionPurgeResponse<AzionPurge> = await client.purge.purgeURL([
+  'http://example.com/image.jpg',
+]);
 if (purgeResult) {
   console.log(`Purge successful: ${purgeResult.items}`);
 }
 
-const cacheKeyResult: Purge | null = await client.purge.purgeCacheKey(['my-cache-key-1', 'my-cache-key-2']);
+const { data: cacheKeyResult }: AzionPurgeResponse<AzionPurge> = await client.purge.purgeCacheKey([
+  'my-cache-key-1',
+  'my-cache-key-2',
+]);
 if (cacheKeyResult) {
   console.log(`Cache key purge successful: ${cacheKeyResult.items}`);
 }
 
-const wildcardResult: Purge | null = await client.purge.purgeWildCard(['http://example.com/*']);
+const { data: wildcardResult }: AzionPurgeResponse<AzionPurge> = await client.purge.purgeWildCard([
+  'http://example.com/*',
+]);
 if (wildcardResult) {
   console.log(`Wildcard purge successful: ${wildcardResult.items}`);
 }

--- a/packages/client/README.MD
+++ b/packages/client/README.MD
@@ -69,17 +69,17 @@ import { createClient } from 'azion';
 
 const client = createClient({ token: 'your-api-token', debug: true });
 
-const newBucket = await client.storage.createBucket('my-new-bucket', 'public');
+const { data: newBucket } = await client.storage.createBucket('my-new-bucket', 'public');
 if (newBucket) {
   console.log(`Bucket created with name: ${newBucket.name}`);
 }
 
-const allBuckets = await client.storage.getBuckets();
+const { data: allBuckets } = await client.storage.getBuckets();
 if (allBuckets) {
-  console.log(`Retrieved ${allBuckets.length} buckets`);
+  console.log(`Retrieved ${allBuckets.count} buckets`);
 }
 
-const deletedBucket = await client.storage.deleteBucket('my-bucket');
+const { data: deletedBucket } = await client.storage.deleteBucket('my-bucket');
 if (deletedBucket) {
   console.log(`Bucket deleted with name: ${deletedBucket.name}`);
 }
@@ -89,21 +89,25 @@ if (deletedBucket) {
 
 ```typescript
 import { createClient } from 'azion';
-import { AzionClient, Bucket } from 'azion/storage/types';
+import { AzionClient, AzionStorageResponse, AzionBucket, AzionDeletedBucket, AzionListBuckets } from 'azion/storage';
 
 const client: AzionClient = createClient({ token: 'your-api-token', debug: true });
 
-const newBucket: Bucket | null = await client.storage.createBucket('my-new-bucket', 'public');
+const { data: newBucket }: AzionStorageResponse<AzionBucket> = await client.storage.createBucket(
+  'my-new-bucket',
+  'public',
+);
 if (newBucket) {
   console.log(`Bucket created with name: ${newBucket.name}`);
 }
 
-const allBuckets: Bucket[] | null = await client.storage.getBuckets();
+const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.storage.getBuckets();
 if (allBuckets) {
-  console.log(`Retrieved ${allBuckets.length} buckets`);
+  console.log(`Retrieved ${allBuckets.count} buckets`);
 }
 
-const deletedBucket: Bucket | null = await client.storage.deleteBucket('my-bucket');
+const { data: deletedBucket }: AzionStorageResponse<AzionDeletedBucket> =
+  await client.storage.deleteBucket('my-bucket');
 if (deletedBucket) {
   console.log(`Bucket deleted with name: ${deletedBucket.name}`);
 }

--- a/packages/client/README.MD
+++ b/packages/client/README.MD
@@ -89,7 +89,7 @@ if (deletedBucket) {
 
 ```typescript
 import { createClient } from 'azion';
-import { AzionClient, AzionStorageResponse, AzionBucket, AzionDeletedBucket, AzionListBuckets } from 'azion/storage';
+import { AzionClient, AzionStorageResponse, AzionBucket, AzionDeletedBucket, AzionBuckets } from 'azion/storage';
 
 const client: AzionClient = createClient({ token: 'your-api-token', debug: true });
 
@@ -101,7 +101,7 @@ if (newBucket) {
   console.log(`Bucket created with name: ${newBucket.name}`);
 }
 
-const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.storage.getBuckets();
+const { data: allBuckets }: AzionStorageResponse<AzionBuckets> = await client.storage.getBuckets();
 if (allBuckets) {
   console.log(`Retrieved ${allBuckets.count} buckets`);
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -51,7 +51,7 @@ export interface AzionClient {
    *
    * @example
    * // Create a new database
-   * const newDatabase = await client.sql.createDatabase('my-new-db');
+   * const { data: newDatabase } = await client.sql.createDatabase('my-new-db');
    *
    * @example
    * // Get all databases
@@ -59,7 +59,7 @@ export interface AzionClient {
    *
    * @example
    * // Get a specific database and perform operations
-   * const { data:db, error } = await client.sql.getDatabase('my-db');
+   * const { data: db, error } = await client.sql.getDatabase('my-db');
    * if (db) {
    *   // Execute a query
    *   const queryResult = await db.query(['SELECT * FROM users WHERE id = ?', 1]);
@@ -71,7 +71,7 @@ export interface AzionClient {
    *   ], ['John Doe', 'john@example.com', 1]);
    *
    *   // List tables in the database
-   *   const tables = await db.listTables();
+   *   const tables = await db.getTables();
    * }
    *
    * @example

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -16,26 +16,26 @@ export interface AzionClient {
    *
    * @example
    * // Get all buckets
-   * const allBuckets = await client.storage.getBuckets({ params: { page: 1, page_size: 10 } });
+   * const { data: allBuckets } = await client.storage.getBuckets({ params: { page: 1, page_size: 10 } });
    *
    * @example
    * // Get a specific bucket and perform operations
-   * const bucket = await client.storage.getBucket({ name: 'my-bucket' });
+   * const { data: bucket } = await client.storage.getBucket({ name: 'my-bucket' });
    * if (bucket) {
    *   // Upload a new object
-   *   const newObject = await bucket.createObject({ key: 'example.txt', content: 'Hello, World!' });
+   *   const { data: newObject } = await bucket.createObject({ key: 'example.txt', content: 'Hello, World!' });
    *
    *   // Get all objects in the bucket
-   *   const objects = await bucket.getObjects({ params: { page: 1, page_size: 10 } });
+   *   const { data: objects } = await bucket.getObjects({ params: { page: 1, page_size: 10 } });
    *
    *   // Get a specific object
-   *   const object = await bucket.getObjectByKey({ key: 'example.txt' });
+   *   const { data: object, error } = await bucket.getObjectByKey({ key: 'example.txt' });
    *
    *   // Update an object
-   *   const updatedObject = await bucket.updateObject({ key: 'example.txt', content: 'Updated content' });
+   *   const { data: updatedObject } = await bucket.updateObject({ key: 'example.txt', content: 'Updated content' });
    *
    *   // Delete an object
-   *   const deletedObject = await bucket.deleteObject({ key: 'example.txt' });
+   *   const { data: deletedObject } = await bucket.deleteObject({ key: 'example.txt' });
    * }
    *
    * @example

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -26,7 +26,7 @@ export interface AzionClient {
    *   const { data: newObject } = await bucket.createObject({ key: 'example.txt', content: 'Hello, World!' });
    *
    *   // Get all objects in the bucket
-   *   const { data: objects } = await bucket.getObjects({ params: { page: 1, page_size: 10 } });
+   *   const { data: objectsResult } = await bucket.getObjects({ params: { page: 1, page_size: 10 } });
    *
    *   // Get a specific object
    *   const { data: object, error } = await bucket.getObjectByKey({ key: 'example.txt' });

--- a/packages/purge/README.md
+++ b/packages/purge/README.md
@@ -82,25 +82,25 @@ You can create a client instance with specific configurations.
 import { purgeURL } from 'azion/purge';
 
 const url = ['http://www.domain.com/path/image.jpg'];
-const response = await purgeURL(url, { debug: true });
+const { data: response, error } = await purgeURL(url, { debug: true });
 if (response) {
   console.log('Purge successful:', response);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { purgeURL, AzionPurge } from 'azion/purge';
+import { purgeURL, AzionPurgeResponse, AzionPurge } from 'azion/purge';
 
 const url: string[] = ['http://www.domain.com/path/image.jpg'];
-const response: AzionPurge | null = await purgeURL(url, { debug: true });
+const { data: response, error }: AzionPurgeResponse<AzionPurge> = await purgeURL(url, { debug: true });
 if (response) {
   console.log('Purge successful:', response);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
@@ -112,25 +112,25 @@ if (response) {
 import { purgeCacheKey } from 'azion/purge';
 
 const cacheKey = ['http://www.domain.com/path/image.jpg'];
-const response = await purgeCacheKey(cacheKey, { debug: true });
+const { data: response, error } = await purgeCacheKey(cacheKey, { debug: true });
 if (response) {
   console.log('Purge successful:', response);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { purgeCacheKey, AzionPurge } from 'azion/purge';
+import { purgeCacheKey, AzionPurge, AzionPurgeResponse } from 'azion/purge';
 
 const cacheKey: string[] = ['http://www.domain.com/path/image.jpg'];
-const response: AzionPurge | null = await purgeCacheKey(cacheKey, { debug: true });
+const { data: response, error }: AzionPurgeResponse<AzionPurge> = await purgeCacheKey(cacheKey, { debug: true });
 if (response) {
   console.log('Purge successful:', response);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
@@ -142,25 +142,25 @@ if (response) {
 import { purgeWildCard } from 'azion/purge';
 
 const wildcard = ['http://www.domain.com/path/image.jpg*'];
-const response = await purgeWildCard(wildcard, { debug: true });
+const { data: response, error } = await purgeWildCard(wildcard, { debug: true });
 if (response) {
   console.log('Purge successful:', response);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { purgeWildCard, AzionPurge } from 'azion/purge';
+import { purgeWildCard, AzionPurge, AzionPurgeResponse } from 'azion/purge';
 
 const wildcard: string[] = ['http://www.domain.com/path/image.jpg*'];
-const response: AzionPurge | null = await purgeWildCard(wildcard, { debug: true });
+const { data: response, error }: AzionPurgeResponse<AzionPurge> = await purgeWildCard(wildcard, { debug: true });
 if (response) {
   console.log('Purge successful:', response);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
@@ -173,54 +173,60 @@ import { createClient } from 'azion/purge';
 
 const client = createClient({ token: 'your-api-token', options: { debug: true } });
 
-const purgeURLResponse = await client.purgeURL(['http://www.domain.com/path/image.jpg']);
+const { data: purgeURLResponse } = await client.purgeURL(['http://www.domain.com/path/image.jpg']);
 if (purgeURLResponse) {
   console.log('Purge successful:', purgeURLResponse);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 
-const purgeCacheKeyResponse = await client.purgeCacheKey(['http://www.domain.com/path/image.jpg']);
+const { data: purgeCacheKeyResponse } = await client.purgeCacheKey(['http://www.domain.com/path/image.jpg']);
 if (purgeCacheKeyResponse) {
   console.log('Purge successful:', purgeCacheKeyResponse);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 
-const purgeWildCardResponse = await client.purgeWildCard(['http://www.domain.com/path/image.jpg*']);
+const { data: purgeWildCardResponse } = await client.purgeWildCard(['http://www.domain.com/path/image.jpg*']);
 if (purgeWildCardResponse) {
   console.log('Purge successful:', purgeWildCardResponse);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { createClient, AzionPurge, AzionPurgeClient } from 'azion/purge';
+import { createClient, AzionPurge, AzionPurgeClient, AzionPurgeResponse } from 'azion/purge';
 
 const client: AzionPurgeClient = createClient({ token: 'your-api-token', options: { debug: true } });
 
-const purgeURLResponse: AzionPurge | null = await client.purgeURL(['http://www.domain.com/path/image.jpg']);
+const { data: purgeURLResponse, error }: AzionPurgeResponse<AzionPurge> = await client.purgeURL([
+  'http://www.domain.com/path/image.jpg',
+]);
 if (purgeURLResponse) {
   console.log('Purge successful:', purgeURLResponse);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 
-const purgeCacheKeyResponse: AzionPurge | null = await client.purgeCacheKey(['http://www.domain.com/path/image.jpg']);
+const { data: purgeCacheKeyResponse, error }: AzionPurgeResponse<AzionPurge> = await client.purgeCacheKey([
+  'http://www.domain.com/path/image.jpg',
+]);
 if (purgeCacheKeyResponse) {
   console.log('Purge successful:', purgeCacheKeyResponse);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 
-const purgeWildCardResponse: AzionPurge | null = await client.purgeWildCard(['http://www.domain.com/path/image.jpg*']);
+const { data: purgeWildCardResponse, error }: AzionPurgeResponse<AzionPurge> = await client.purgeWildCard([
+  'http://www.domain.com/path/image.jpg*',
+]);
 if (purgeWildCardResponse) {
   console.log('Purge successful:', purgeWildCardResponse);
 } else {
-  console.error('Purge failed');
+  console.error('Purge failed', error);
 }
 ```
 
@@ -237,7 +243,7 @@ Purge a URL from the Azion Edge cache.
 
 **Returns:**
 
-- `Promise<Purge | null>` - The purge response or null if the purge failed.
+- `Promise<AzionPurgeResponse<AzionPurge>>` - The purge response or error if the purge failed.
 
 ### `purgeCacheKey`
 
@@ -250,7 +256,7 @@ Purge a Cache Key from the Azion Edge cache.
 
 **Returns:**
 
-- `Promise<Purge | null>` - The purge response or null if the purge failed.
+- `Promise<AzionPurgeResponse<AzionPurge>>` - The purge response or error if the purge failed.
 
 ### `purgeWildCard`
 
@@ -263,7 +269,7 @@ Purge using a wildcard expression from the Azion Edge cache.
 
 **Returns:**
 
-- `Promise<Purge | null>` - The purge response or null if the purge failed.
+- `Promise<AzionPurgeResponse<AzionPurge>>` - The purge response or error if the purge failed.
 
 ### `createClient`
 
@@ -290,9 +296,9 @@ Configuration options for the Purge client.
 
 An object with methods to interact with Purge.
 
-- `purgeURL: (urls: string[], options?: AzionClientOptions) => Promise<Purge | null>`
-- `purgeCacheKey: (cacheKeys: string[], options?: AzionClientOptions) => Promise<Purge | null>`
-- `purgeWildCard: (wildcards: string[], options?: AzionClientOptions) => Promise<Purge | null>`
+- `purgeURL: (urls: string[], options?: AzionClientOptions) => Promise<AzionPurgeResponse<AzionPurge>>`
+- `purgeCacheKey: (cacheKeys: string[], options?: AzionClientOptions) => Promise<AzionPurgeResponse<AzionPurge>>`
+- `purgeWildCard: (wildcards: string[], options?: AzionClientOptions) => Promise<AzionPurgeResponse<AzionPurge>>`
 
 ### `Purge`
 

--- a/packages/purge/src/index.test.ts
+++ b/packages/purge/src/index.test.ts
@@ -1,9 +1,9 @@
 import { createClient, purgeCacheKey, purgeURL, purgeWildCard } from '../src/index';
 import { AzionPurgeClient } from '../src/types';
 
-import * as services from '../src/services';
+import * as services from '../src/services/api/index';
 
-jest.mock('../src/services');
+jest.mock('../src/services/api/index');
 
 describe('Purge Module', () => {
   const mockToken = 'mock-token';
@@ -37,15 +37,17 @@ describe('Purge Module', () => {
       (services.postPurgeURL as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await purgeURL(['http://example.com'], { debug: mockDebug });
-      expect(result).toEqual({ state: 'executed', items: ['http://example.com'] });
+      expect(result.data).toEqual({ state: 'executed', items: ['http://example.com'] });
       expect(services.postPurgeURL).toHaveBeenCalledWith(mockToken, ['http://example.com'], mockDebug);
     });
 
-    it('should return null on failure', async () => {
-      (services.postPurgeURL as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.postPurgeURL as jest.Mock).mockResolvedValue({
+        error: { message: 'Invalid Tokne', operation: 'purgeURL' },
+      });
 
       const result = await purgeURL(['http://example.com'], { debug: mockDebug });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'Invalid Tokne', operation: 'purgeURL' } });
     });
   });
 
@@ -55,15 +57,17 @@ describe('Purge Module', () => {
       (services.postPurgeCacheKey as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await purgeCacheKey(['cache-key-1'], { debug: true });
-      expect(result).toEqual({ state: 'executed', items: ['cache-key-1'] });
+      expect(result.data).toEqual({ state: 'executed', items: ['cache-key-1'] });
       expect(services.postPurgeCacheKey).toHaveBeenCalledWith(mockToken, ['cache-key-1'], mockDebug);
     });
 
-    it('should return null on failure', async () => {
-      (services.postPurgeCacheKey as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.postPurgeCacheKey as jest.Mock).mockResolvedValue({
+        error: { message: 'Invalid Token', operation: 'purge cache key' },
+      });
 
       const result = await purgeCacheKey(['cache-key-1'], { debug: mockDebug });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'Invalid Token', operation: 'purge cache key' } });
     });
   });
 
@@ -73,15 +77,17 @@ describe('Purge Module', () => {
       (services.postPurgeWildcard as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await purgeWildCard(['http://example.com/*'], { debug: mockDebug });
-      expect(result).toEqual({ state: 'executed', items: ['http://example.com/*'] });
+      expect(result.data).toEqual({ state: 'executed', items: ['http://example.com/*'] });
       expect(services.postPurgeWildcard).toHaveBeenCalledWith(mockToken, ['http://example.com/*'], mockDebug);
     });
 
-    it('should return null on failure', async () => {
-      (services.postPurgeWildcard as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.postPurgeWildcard as jest.Mock).mockResolvedValue({
+        error: { message: 'Invalid Token', operation: 'purge wildcard' },
+      });
 
       const result = await purgeWildCard(['http://example.com/*'], { debug: mockDebug });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'Invalid Token', operation: 'purge wildcard' } });
     });
   });
 

--- a/packages/purge/src/services/api/index.ts
+++ b/packages/purge/src/services/api/index.ts
@@ -4,15 +4,31 @@ const BASE_URL =
   process.env.AZION_ENV === 'stage'
     ? 'https://stage-api.azion.com/v4/edge/purge'
     : 'https://api.azion.com/v4/edge/purge';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleApiError = (fields: string[], data: any, operation: string) => {
+  let error = { message: 'Error unknown', operation: operation };
+  fields.forEach((field: string) => {
+    if (data[field]) {
+      const message = Array.isArray(data[field]) ? data[field].join(', ') : data[field];
+      error = {
+        message: message,
+        operation: operation,
+      };
+    }
+  });
+  return error;
+};
+
 /**
  * Purge URLs from the Azion Edge cache.
  *
  * @param {string} token - Authentication token for Azion API.
  * @param {string[]} urls - URLs to purge.
  * @param {boolean} [debug] - Enable debug mode for detailed logging.
- * @returns {Promise<ApiPurgeResponse | null>} The purge response or null if the purge failed.
+ * @returns {Promise<ApiPurgeResponse>} The purge response or error message
  */
-const postPurgeURL = async (token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse | null> => {
+const postPurgeURL = async (token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse> => {
   return postPurge(`${BASE_URL}/url`, token, urls, debug);
 };
 
@@ -22,9 +38,9 @@ const postPurgeURL = async (token: string, urls: string[], debug?: boolean): Pro
  * @param {string} token - Authentication token for Azion API.
  * @param {string[]} urls - Cache keys to purge.
  * @param {boolean} [debug] - Enable debug mode for detailed logging.
- * @returns {Promise<ApiPurgeResponse | null>} The purge response or null if the purge failed.
+ * @returns {Promise<ApiPurgeResponse>} The purge response or error message
  */
-const postPurgeCacheKey = async (token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse | null> => {
+const postPurgeCacheKey = async (token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse> => {
   return postPurge(`${BASE_URL}/cachekey`, token, urls, debug);
 };
 
@@ -34,9 +50,9 @@ const postPurgeCacheKey = async (token: string, urls: string[], debug?: boolean)
  * @param {string} token - Authentication token for Azion API.
  * @param {string[]} urls - Wildcard expressions to purge.
  * @param {boolean} [debug] - Enable debug mode for detailed logging.
- * @returns {Promise<ApiPurgeResponse | null>} The purge response or null if the purge failed.
+ * @returns {Promise<ApiPurgeResponse>} The purge response or error message
  */
-const postPurgeWildcard = async (token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse | null> => {
+const postPurgeWildcard = async (token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse> => {
   return postPurge(`${BASE_URL}/wildcard`, token, urls, debug);
 };
 
@@ -47,14 +63,9 @@ const postPurgeWildcard = async (token: string, urls: string[], debug?: boolean)
  * @param {string} token - Authentication token for Azion API.
  * @param {string[]} urls - Items to purge.
  * @param {boolean} [debug] - Enable debug mode for detailed logging.
- * @returns {Promise<ApiPurgeResponse | null>} The purge response or null if the purge failed.
+ * @returns {Promise<ApiPurgeResponse>} The purge response or error if the purge failed.
  */
-const postPurge = async (
-  url: string,
-  token: string,
-  urls: string[],
-  debug?: boolean,
-): Promise<ApiPurgeResponse | null> => {
+const postPurge = async (url: string, token: string, urls: string[], debug?: boolean): Promise<ApiPurgeResponse> => {
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -66,12 +77,18 @@ const postPurge = async (
       credentials: 'include',
       body: JSON.stringify({ items: urls, layer: 'edge_cache' }),
     });
-    const data = await response.json();
-    if (debug) console.log('Response:', data);
-    return data;
+    const result = await response.json();
+    if (!result.data) {
+      result.error = handleApiError(['detail', 'error'], result, 'post purge');
+      return {
+        error: result.error ?? JSON.stringify(result),
+      };
+    }
+    if (debug) console.log('Response:', result);
+    return result;
   } catch (error) {
     if (debug) console.error('Error purging:', error);
-    return null;
+    throw error;
   }
 };
 

--- a/packages/purge/src/services/api/index.ts
+++ b/packages/purge/src/services/api/index.ts
@@ -79,7 +79,8 @@ const postPurge = async (url: string, token: string, urls: string[], debug?: boo
     });
     const result = await response.json();
     if (!result.data) {
-      result.error = handleApiError(['detail', 'error'], result, 'post purge');
+      if (debug) console.log('Response Error:', result);
+      result.error = handleApiError(['detail', 'error', 'items'], result, 'post purge');
       return {
         error: result.error ?? JSON.stringify(result),
       };

--- a/packages/purge/src/services/api/types.ts
+++ b/packages/purge/src/services/api/types.ts
@@ -1,0 +1,10 @@
+export interface ApiPurgeResponse {
+  state?: 'executed' | 'pending';
+  data?: {
+    items: string[];
+  };
+  error?: {
+    message: string;
+    operation: string;
+  };
+}

--- a/packages/purge/src/types.ts
+++ b/packages/purge/src/types.ts
@@ -1,7 +1,8 @@
-export interface ApiPurgeResponse {
-  state: 'executed' | 'pending';
-  data: {
-    items: string[];
+export interface AzionPurgeResponse<T> {
+  data?: T;
+  error?: {
+    message: string;
+    operation: string;
   };
 }
 
@@ -16,49 +17,49 @@ export interface AzionPurgeClient {
    *
    * @param {string[]} url - URLs to purge.
    * @param {AzionClientOptions} [options] - Client options including debug mode.
-   * @returns {Promise<AzionPurge | null>} The purge response or null if the purge failed.
+   * @returns {Promise<AzionPurgeResponse<AzionPurge>>} The purge response or error if the purge failed.
    *
    * @example
-   * const response = await purgeClient.purgeURL(['http://www.domain.com/path/image.jpg'], { debug: true });
+   * const { data: response, error } = await purgeClient.purgeURL(['http://www.domain.com/path/image.jpg'], { debug: true });
    * if (response) {
    *   console.log('Purge successful:', response);
    * } else {
-   *   console.error('Purge failed');
+   *   console.error('Purge failed', error);
    * }
    */
-  purgeURL: (urls: string[]) => Promise<AzionPurge | null>;
+  purgeURL: (urls: string[]) => Promise<AzionPurgeResponse<AzionPurge>>;
   /**
    * Purge a Cache Key from the Azion Edge cache.
    *
    * @param {string[]} cacheKey - Cache Keys to purge.
    * @param {AzionClientOptions} [options] - Client options including debug mode.
-   * @returns {Promise<AzionPurge | null>} The purge response or null if the purge failed.
+   * @returns {Promise<AzionPurgeResponse<AzionPurge>>} The purge response or error if the purge failed.
    *
    * @example
-   * const response = await purgeClient.purgeCacheKey(['http://www.domain.com/path/image.jpg'], { debug: true });
+   * const { data: response, error } = await purgeClient.purgeCacheKey(['http://www.domain.com/path/image.jpg'], { debug: true });
    * if (response) {
    *   console.log('Purge successful:', response);
    * } else {
-   *   console.error('Purge failed');
+   *   console.error('Purge failed', error);
    * }
    */
-  purgeCacheKey: (cacheKeys: string[]) => Promise<AzionPurge | null>;
+  purgeCacheKey: (cacheKeys: string[]) => Promise<AzionPurgeResponse<AzionPurge>>;
   /**
    * Purge using a wildcard expression from the Azion Edge cache.
    *
    * @param {string[]} wildcard - Wildcard expressions to purge.
    * @param {AzionClientOptions} [options] - Client options including debug mode.
-   * @returns {Promise<AzionPurge | null>} The purge response or null if the purge failed.
+   * @returns {Promise<AzionPurgeResponse<AzionPurge>>} The purge response or error if the purge failed.
    *
    * @example
-   * const response = await purgeClient.purgeWildCard(['http://www.domain.com/path/image.jpg*'], { debug: true });
+   * const { data: response, error } = await purgeClient.purgeWildCard(['http://www.domain.com/path/image.jpg*'], { debug: true });
    * if (response) {
    *   console.log('Purge successful:', response);
    * } else {
-   *   console.error('Purge failed');
+   *   console.error('Purge failed', error);
    * }
    */
-  purgeWildCard: (wildcards: string[]) => Promise<AzionPurge | null>;
+  purgeWildCard: (wildcards: string[]) => Promise<AzionPurgeResponse<AzionPurge>>;
 }
 
 /**

--- a/packages/sql/README.MD
+++ b/packages/sql/README.MD
@@ -112,7 +112,7 @@ if (data) {
 import { createDatabase, AzionDatabase } from 'azion/sql';
 import type { AzionDatabaseResponse, AzionDatabase } from 'azion/sql';
 
-const { data, error }: AzionDatabaseResponse = await createDatabase('my-new-database', { debug: true });
+const { data, error }: AzionDatabaseResponse<AzionDatabase> = await createDatabase('my-new-database', { debug: true });
 if (data) {
   const database: AzionDatabase = data;
   console.log(`Database created with ID: ${database.id}`);
@@ -142,7 +142,7 @@ if (data) {
 import { deleteDatabase } from 'azion/sql';
 import type { AzionDatabaseResponse } from 'azion/sql';
 
-const { data, error }: AzionDatabaseResponse = await deleteDatabase(123, { debug: true });
+const { data, error }: AzionDatabaseResponse<{ id: number }> = await deleteDatabase(123, { debug: true });
 if (data) {
   console.log(`Database ${data.id} deleted successfully`);
 } else {
@@ -171,7 +171,7 @@ if (data) {
 import { getDatabase } from 'azion/sql';
 import type { AzionDatabaseResponse, AzionDatabase } from 'azion/sql';
 
-const { data, error }: AzionDatabaseResponse = await getDatabase('my-db', { debug: true });
+const { data, error }: AzionDatabaseResponse<AzionDatabase> = await getDatabase('my-db', { debug: true });
 if (data) {
   const database: AzionDatabase = data;
   console.log(`Retrieved database: ${database.id}`);
@@ -199,12 +199,14 @@ if (data) {
 
 ```typescript
 import { getDatabases } from 'azion/sql';
-import type { AzionDatabaseResponse, AzionDatabase } from 'azion/sql';
+import type { AzionDatabaseResponse, AzionDatabaseCollections } from 'azion/sql';
 
-const { data, error }: AzionDatabaseResponse = await getDatabases({ page: 1, page_size: 10 }, { debug: true });
-if (data) {
-  const databases: AzionDatabase[] = data;
-  console.log(`Retrieved ${databases.length} databases`);
+const { data: allDatabases, error }: AzionDatabaseResponse<AzionDatabaseCollections> = await getDatabases(
+  { page: 1, page_size: 10 },
+  { debug: true },
+);
+if (allDatabases) {
+  console.log(`Retrieved ${allDatabases.count} databases`);
 } else {
   console.error('Failed to retrieve databases', error);
 }
@@ -228,13 +230,19 @@ if (result) {
 **TypeScript:**
 
 ```typescript
-import { useQuery, AzionDatabaseQueryResponse } from 'azion/sql';
+import { useQuery, AzionDatabaseQueryResponse, AzionDatabaseResponse } from 'azion/sql';
 
-const result: AzionDatabaseQueryResponse | null = await useQuery('my-db', ['SELECT * FROM users'], { debug: true });
+const { data: result, error }: AzionDatabaseResponse<AzionDatabaseQueryResponse> = await useQuery(
+  'my-db',
+  ['SELECT * FROM users'],
+  {
+    debug: true,
+  },
+);
 if (result) {
   console.log(`Query executed. Rows returned: ${result.rows.length}`);
 } else {
-  console.error('Query execution failed');
+  console.error('Query execution failed', error);
 }
 ```
 
@@ -277,9 +285,9 @@ if (result?.state === 'executed') {
 **JavaScript:**
 
 ```javascript
-import { listTables } from 'azion/sql';
+import { getTables } from 'azion/sql';
 
-const { data, error } = await listTables('my-db', { debug: true });
+const { data, error } = await getTables('my-db', { debug: true });
 
 if (data) {
   console.log(data);
@@ -291,10 +299,10 @@ if (data) {
 **TypeScript:**
 
 ```typescript
-import { listTables } from 'azion/sql';
-import type { AzionDatabaseQueryResponse } from 'azion/sql';
+import { getTables } from 'azion/sql';
+import type { AzionDatabaseResponse, AzionDatabaseQueryResponse } from 'azion/sql';
 
-const { data, error }: AzionDatabaseQueryResponse = await listTables('my-db', { debug: true });
+const { data, error }: AzionDatabaseResponse<AzionDatabaseQueryResponse> = await getTables('my-db', { debug: true });
 
 if (data) {
   console.log(data);
@@ -316,7 +324,7 @@ Creates a new database.
 
 **Returns:**
 
-- `Promise<AzionDatabaseResponse>` - The created database object or error.
+- `Promise<AzionDatabaseResponse<AzionDatabase>>` - The created database object or error.
 
 **Example:**
 
@@ -340,7 +348,7 @@ Deletes a database by its ID.
 
 **Returns:**
 
-- `Promise<AzionDatabaseResponse>` - Object confirming deletion or error.
+- `Promise<AzionDatabaseResponse<{ id: number }>>` - Object confirming deletion or error.
 
 **Example:**
 
@@ -364,7 +372,7 @@ Retrieves a database by its Name.
 
 **Returns:**
 
-- `Promise<AzionDatabaseResponse>` - The retrieved database object or error.
+- `Promise<AzionDatabaseResponse<AzionDatabase>>` - The retrieved database object or error.
 
 **Example:**
 
@@ -388,15 +396,15 @@ Retrieves a list of databases with optional filtering and pagination.
 
 **Returns:**
 
-- `Promise<AzionDatabaseResponse>` - Array of database objects or error.
+- `Promise<AzionDatabaseResponse<AzionDatabaseCollections>>` - Array of database objects or error.
 
 **Example:**
 
 ```javascript
-const { data, error } = await sqlClient.getDatabases({ page: 1, page_size: 10, search: 'test' });
-if (data) {
-  console.log(`Retrieved ${data.length} databases`);
-  data.forEach((db) => console.log(`- ${db.name} (ID: ${db.id})`));
+const { data: allDatabases, error } = await sqlClient.getDatabases({ page: 1, page_size: 10, search: 'test' });
+if (allDatabases) {
+  console.log(`Retrieved ${allDatabases.count} databases`);
+  allDatabases.results.forEach((db) => console.log(`- ${db.name} (ID: ${db.id})`));
 } else {
   console.error('Failed to retrieve databases', error);
 }
@@ -414,7 +422,7 @@ Executes a query on a specific database.
 
 **Returns:**
 
-- `Promise<AzionDatabaseQueryResponse>` - Query result object or error.
+- `Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>` - Query result object or error.
 
 **Example:**
 
@@ -439,7 +447,7 @@ Executes a set of SQL statements on a specific database.
 
 **Returns:**
 
-- `Promise<AzionDatabaseQueryResponse>` - Execution result object or error.
+- `Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>` - Execution result object or error.
 
 **Example:**
 
@@ -479,12 +487,12 @@ Configuration options for the SQL client.
 
 An object with methods to interact with SQL databases.
 
-- `createDatabase: (name: string) => Promise<AzionDatabaseResponse>`
-- `deleteDatabase: (id: number) => Promise<AzionDatabaseResponse>`
-- `getDatabase: (name: string) => Promise<AzionDatabase | null>`
-- `getDatabases: (params?: AzionDatabaseCollectionOptions) => Promise<AzionDatabaseResponse>`
-- `useQuery: (name: string, statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseQueryResponse>`
-- `useExecute: (name: string, statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseExecutionResponse>`
+- `createDatabase: (name: string) => Promise<AzionDatabaseResponse<AzionDatabase>>`
+- `deleteDatabase: (id: number) => Promise<AzionDatabaseResponse<{ id: number }>>`
+- `getDatabase: (name: string) => Promise<AzionDatabaseResponse<AzionDatabase>>`
+- `getDatabases: (params?: AzionDatabaseCollectionOptions) => Promise<AzionDatabaseResponse<AzionDatabaseCollections>>`
+- `useQuery: (name: string, statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
+- `useExecute: (name: string, statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseExecutionResponse>>`
 
 ### `AzionDatabase`
 
@@ -497,9 +505,9 @@ The database object.
 - `createdAt: string`
 - `updatedAt: string`
 - `deletedAt: string | null`
-- `query: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseQueryResponse>`
-- `execute: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseExecutionResponse>`
-- `listTables: (options?: AzionClientOptions) => Promise<AzionDatabaseQueryResponse>`
+- `query: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
+- `execute: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseExecutionResponse>>`
+- `getTables: (options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
 
 ### `AzionDatabaseResponse`
 

--- a/packages/sql/README.MD
+++ b/packages/sql/README.MD
@@ -140,9 +140,9 @@ if (data) {
 
 ```typescript
 import { deleteDatabase } from 'azion/sql';
-import type { AzionDatabaseResponse } from 'azion/sql';
+import type { AzionDatabaseResponse, AzionDatabaseDeleteResponse } from 'azion/sql';
 
-const { data, error }: AzionDatabaseResponse<{ id: number }> = await deleteDatabase(123, { debug: true });
+const { data, error }: AzionDatabaseResponse<AzionDatabaseDeleteResponse> = await deleteDatabase(123, { debug: true });
 if (data) {
   console.log(`Database ${data.id} deleted successfully`);
 } else {
@@ -348,7 +348,7 @@ Deletes a database by its ID.
 
 **Returns:**
 
-- `Promise<AzionDatabaseResponse<{ id: number }>>` - Object confirming deletion or error.
+- `Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>>` - Object confirming deletion or error.
 
 **Example:**
 
@@ -488,7 +488,7 @@ Configuration options for the SQL client.
 An object with methods to interact with SQL databases.
 
 - `createDatabase: (name: string) => Promise<AzionDatabaseResponse<AzionDatabase>>`
-- `deleteDatabase: (id: number) => Promise<AzionDatabaseResponse<{ id: number }>>`
+- `deleteDatabase: (id: number) => Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>>`
 - `getDatabase: (name: string) => Promise<AzionDatabaseResponse<AzionDatabase>>`
 - `getDatabases: (params?: AzionDatabaseCollectionOptions) => Promise<AzionDatabaseResponse<AzionDatabaseCollections>>`
 - `useQuery: (name: string, statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
@@ -509,11 +509,11 @@ The database object.
 - `execute: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseExecutionResponse>>`
 - `getTables: (options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
 
-### `AzionDatabaseResponse`
+### `AzionDatabaseResponse<T>`
 
 The response object from a database operation.
 
-- `data?: AzionDatabase | Pick<AzionDatabase, 'id'>`
+- `data?: T`
 - `error?: { message: string, operation: string }`
 
 ### `QueryResult`
@@ -544,8 +544,7 @@ Optional parameters for filtering and pagination.
 The response object from a query execution.
 
 - `state: 'executed' | 'pending' | 'executed-runtime' | 'failed'`
-- `data: QueryResult[] | NonSelectQueryResult`
-- `error?: { message: string, operation: string }`
+- `data: QueryResult[]`
 - `toObject?: () => JsonObjectQueryExecutionResponse`
 
 ### `AzionDatabaseExecutionResponse`
@@ -553,23 +552,8 @@ The response object from a query execution.
 The response object from a query execution.
 
 - `state: 'executed' | 'pending' | 'executed-runtime' | 'failed'`
-- `data: QueryResult[] | NonSelectQueryResult`
-- `error?: { message: string, operation: string }`
+- `data: QueryResult[]`
 - `toObject?: () => JsonObjectQueryExecutionResponse`
-
-### `NonSelectQueryResult`
-
-The result object for non-select queries.
-
-- `info?: AzionQueryExecutionInfo`
-
-### `AzionQueryExecutionInfo`
-
-Information about the query execution.
-
-- `rowsRead?: number`
-- `rowsWritten?: number`
-- `durationMs?: number`
 
 ### `AzionQueryExecutionParams`
 

--- a/packages/sql/src/index.test.ts
+++ b/packages/sql/src/index.test.ts
@@ -73,9 +73,9 @@ describe('SQL Module', () => {
       jest.spyOn(console, 'log').mockImplementation();
     });
     it('should successfully delete a database', async () => {
-      (servicesApi.deleteEdgeDatabase as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+      (servicesApi.deleteEdgeDatabase as jest.Mock).mockResolvedValue({ state: 'pending', data: { id: 1 } });
       const result = await deleteDatabase(1, { debug: mockDebug });
-      expect(result).toEqual({ data: { id: 1 } });
+      expect(result).toEqual({ data: { id: 1, state: 'pending' } });
       expect(servicesApi.deleteEdgeDatabase).toHaveBeenCalledWith(mockToken, 1, true);
     });
 

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -7,6 +7,7 @@ import type {
   AzionDatabase,
   AzionDatabaseCollectionOptions,
   AzionDatabaseCollections,
+  AzionDatabaseDeleteResponse,
   AzionDatabaseQueryResponse,
   AzionDatabaseResponse,
   AzionSQLClient,
@@ -33,6 +34,7 @@ const createDatabaseMethod = async (
   if (apiResponse.data) {
     return {
       data: {
+        state: apiResponse.state,
         ...apiResponse.data,
         query: (statements: string[]) =>
           queryDatabaseMethod(resolveToken(token), name, statements, {
@@ -68,11 +70,12 @@ const deleteDatabaseMethod = async (
   token: string,
   id: number,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse<{ id: number }>> => {
+): Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>> => {
   const apiResponse = await deleteEdgeDatabase(resolveToken(token), id, resolveDebug(options?.debug));
   if (apiResponse?.data) {
     return {
       data: {
+        state: apiResponse.state ?? 'executed',
         id: apiResponse.data.id,
       },
     };
@@ -325,7 +328,7 @@ const createDatabaseWrapper = async (
  *
  * @param {number} id - ID of the database to delete.
  * @param {AzionClientOptions} [options] - Optional parameters for the deletion.
- * @returns {Promise<AzionDatabaseResponse<{ id: number }>>} Object confirming deletion or error if deletion failed.
+ * @returns {Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>>} Object confirming deletion or error if deletion failed.
  *
  * @example
  * const { data, error } = await deleteDatabase(123, { debug: true });
@@ -338,7 +341,7 @@ const createDatabaseWrapper = async (
 const deleteDatabaseWrapper = (
   id: number,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse<{ id: number }>> =>
+): Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>> =>
   deleteDatabaseMethod(resolveToken(), id, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -474,7 +477,7 @@ const client: CreateAzionSQLClient = (
   const client: AzionSQLClient = {
     createDatabase: (name: string): Promise<AzionDatabaseResponse<AzionDatabase>> =>
       createDatabaseMethod(tokenValue, name, { ...config, debug: debugValue }),
-    deleteDatabase: (id: number): Promise<AzionDatabaseResponse<{ id: number }>> =>
+    deleteDatabase: (id: number): Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>> =>
       deleteDatabaseMethod(tokenValue, id, { ...config, debug: debugValue }),
     getDatabase: (name: string): Promise<AzionDatabaseResponse<AzionDatabase>> =>
       getDatabaseMethod(tokenValue, name, { ...config, debug: debugValue }),

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -4,7 +4,9 @@ import { apiQuery, runtimeQuery } from './services/index';
 import { getAzionSql } from './services/runtime/index';
 import type {
   AzionClientOptions,
+  AzionDatabase,
   AzionDatabaseCollectionOptions,
+  AzionDatabaseCollections,
   AzionDatabaseQueryResponse,
   AzionDatabaseResponse,
   AzionSQLClient,
@@ -26,35 +28,32 @@ const createDatabaseMethod = async (
   token: string,
   name: string,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse> => {
-  const { data, error } = await postEdgeDatabase(resolveToken(token), name, resolveDebug(options?.debug));
-  if (data) {
-    return Promise.resolve({
+): Promise<AzionDatabaseResponse<AzionDatabase>> => {
+  const apiResponse = await postEdgeDatabase(resolveToken(token), name, resolveDebug(options?.debug));
+  if (apiResponse.data) {
+    return {
       data: {
-        ...data,
+        ...apiResponse.data,
         query: (statements: string[]) =>
-          queryDatabaseMethod(resolveToken(token), data.name, statements, {
+          queryDatabaseMethod(resolveToken(token), name, statements, {
             ...options,
             debug: resolveDebug(options?.debug),
           }),
         execute: (statements: string[], options?: AzionClientOptions) =>
-          executeDatabaseMethod(resolveToken(token), data.name, statements, {
+          executeDatabaseMethod(resolveToken(token), name, statements, {
             ...options,
             debug: resolveDebug(options?.debug),
           }),
-        listTables: (options?: AzionClientOptions) =>
-          listTablesWrapper(data.name, {
+        getTables: (options?: AzionClientOptions) =>
+          listTablesWrapper(name, {
             ...options,
             debug: resolveDebug(options?.debug),
           }),
       },
-    } as AzionDatabaseResponse);
+    } as AzionDatabaseResponse<AzionDatabase>;
   }
   return {
-    error: {
-      message: error?.detail ?? 'Failed to create database',
-      operation: 'create database',
-    },
+    error: apiResponse.error,
   };
 };
 
@@ -69,21 +68,18 @@ const deleteDatabaseMethod = async (
   token: string,
   id: number,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse> => {
+): Promise<AzionDatabaseResponse<{ id: number }>> => {
   const apiResponse = await deleteEdgeDatabase(resolveToken(token), id, resolveDebug(options?.debug));
-  if (apiResponse?.state) {
-    return Promise.resolve({
+  if (apiResponse?.data) {
+    return {
       data: {
-        id,
+        id: apiResponse.data.id,
       },
-    });
+    };
   }
-  return Promise.resolve({
-    error: {
-      message: 'Failed to delete database',
-      operation: 'delete database',
-    },
-  });
+  return {
+    error: apiResponse.error,
+  };
 };
 
 /**
@@ -97,34 +93,34 @@ const getDatabaseMethod = async (
   token: string,
   name: string,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse> => {
+): Promise<AzionDatabaseResponse<AzionDatabase>> => {
   if (!name || name === '') {
-    return Promise.resolve({
+    return {
       error: {
         message: 'Database name is required',
         operation: 'get database',
       },
-    });
+    };
   }
   const databaseResponse = await getEdgeDatabases(resolveToken(token), { search: name }, resolveDebug(options?.debug));
   if (!databaseResponse?.results || databaseResponse?.results?.length === 0) {
-    return Promise.resolve({
+    return {
       error: {
         message: `Database with name '${name}' not found`,
         operation: 'get database',
       },
-    });
+    };
   }
   const databaseResult = databaseResponse?.results[0];
   if (!databaseResult || databaseResult.id === undefined || databaseResult.name !== name) {
-    return Promise.resolve({
+    return {
       error: {
         message: `Database with name '${name}' not found`,
         operation: 'get database',
       },
-    });
+    };
   }
-  return Promise.resolve({
+  return {
     data: {
       ...databaseResult,
       query: (statements: string[]) =>
@@ -137,13 +133,13 @@ const getDatabaseMethod = async (
           ...options,
           debug: resolveDebug(options?.debug),
         }),
-      listTables: (options?: AzionClientOptions) =>
+      getTables: (options?: AzionClientOptions) =>
         listTablesWrapper(databaseResult.name, {
           ...options,
           debug: resolveDebug(options?.debug),
         }),
     },
-  } as AzionDatabaseResponse);
+  } as AzionDatabaseResponse<AzionDatabase>;
 };
 
 /**
@@ -157,39 +153,42 @@ const getDatabasesMethod = async (
   token: string,
   params?: AzionDatabaseCollectionOptions,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse> => {
+): Promise<AzionDatabaseResponse<AzionDatabaseCollections>> => {
   const apiResponse = await getEdgeDatabases(resolveToken(token), params, resolveDebug(options?.debug));
   if (apiResponse?.results && apiResponse.results.length > 0) {
     const databases = apiResponse.results.map((db: ApiDatabaseResponse) => {
       return {
         ...db,
-        query: (statements: string[]): Promise<AzionDatabaseQueryResponse | null> =>
+        query: (statements: string[]): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
           queryDatabaseMethod(resolveToken(token), db.name, statements, {
             ...options,
             debug: resolveDebug(options?.debug),
           }),
-        execute: (statements: string[], options?: AzionClientOptions): Promise<AzionDatabaseQueryResponse | null> =>
+        execute: (
+          statements: string[],
+          options?: AzionClientOptions,
+        ): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
           executeDatabaseMethod(resolveToken(token), db.name, statements, {
             ...options,
             debug: resolveDebug(options?.debug),
           }),
-        listTables: (options?: AzionClientOptions): Promise<AzionDatabaseQueryResponse | null> =>
+        getTables: (options?: AzionClientOptions): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
           listTablesWrapper(db.name, {
             ...options,
             debug: resolveDebug(options?.debug),
           }),
       };
     });
-    return Promise.resolve({
-      data: databases as AzionDatabaseResponse['data'],
-    });
+    return {
+      data: {
+        count: apiResponse.count,
+        databases,
+      },
+    };
   }
-  return Promise.resolve({
-    error: {
-      message: apiResponse?.detail ?? 'Failed to retrieve databases',
-      operation: 'get databases',
-    },
-  });
+  return {
+    error: apiResponse.error,
+  };
 };
 
 /**
@@ -205,27 +204,25 @@ const queryDatabaseMethod = async (
   name: string,
   statements: string[],
   options?: AzionClientOptions,
-): Promise<AzionDatabaseQueryResponse> => {
+): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> => {
   if (!name || name === '') {
-    return Promise.resolve({
-      state: 'failed',
+    return {
       error: {
         message: 'Database name is required',
         operation: 'query database',
       },
-    });
+    };
   }
   if (options?.debug) {
     console.log(`Executing statements on database ${name}: ${statements}`);
   }
   if (!Array.isArray(statements) || statements.length === 0) {
-    return Promise.resolve({
-      state: 'failed',
+    return {
       error: {
         message: 'No statements to execute. Please provide at least one statement. e.g ["SELECT * FROM users"]',
         operation: 'query database',
       },
-    });
+    };
   }
   const isStatement = statements.some((statement) =>
     ['SELECT', 'PRAGMA'].some((keyword) => statement.trim().toUpperCase().startsWith(keyword)),
@@ -253,28 +250,26 @@ const executeDatabaseMethod = async (
   name: string,
   statements: string[],
   options?: AzionClientOptions,
-): Promise<AzionDatabaseQueryResponse> => {
+): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> => {
   if (options?.debug) {
     console.log(`Executing statements on database ${name}: ${statements}`);
   }
   if (!name || name === '') {
-    return Promise.resolve({
-      state: 'failed',
+    return {
       error: {
         message: 'Database name is required',
         operation: 'execute database',
       },
-    });
+    };
   }
   if (!Array.isArray(statements) || statements.length === 0) {
-    return Promise.resolve({
-      state: 'failed',
+    return {
       error: {
         message:
           'No statements to execute. Please provide at least one statement. e.g ["INSERT INTO users (name) VALUES (\'John\')"]',
         operation: 'execute database',
       },
-    });
+    };
   }
   const isWriteStatement = statements.some((statement) =>
     ['INSERT', 'UPDATE', 'DELETE'].some((keyword) => statement.trim().toUpperCase().startsWith(keyword)),
@@ -283,26 +278,23 @@ const executeDatabaseMethod = async (
     ['CREATE', 'ALTER', 'DROP', 'TRUNCATE'].some((keyword) => statement.trim().toUpperCase().startsWith(keyword)),
   );
   if (!isAdminStatement && !isWriteStatement) {
-    return Promise.resolve({
-      state: 'failed',
+    return {
       error: {
         message: 'Only write statements are allowed',
         operation: 'execute database',
       },
-    });
+    };
   }
   if (isAdminStatement && options?.force === false) {
-    return Promise.resolve({
-      state: 'failed',
+    return {
       error: {
         message: 'To admin statements, you need to set the force option to true',
         operation: 'execute database',
       },
-    });
+    };
   }
   const resultQuery = await apiQuery(token, name, statements, options);
   return {
-    state: resultQuery.state,
     data: resultQuery.data,
   };
 };
@@ -312,7 +304,7 @@ const executeDatabaseMethod = async (
  *
  * @param {string} name - Name of the database to create.
  * @param {AzionClientOptions} [options] - Optional parameters for the deletion.
- * @returns {Promise<AzionDatabaseResponse>} The created database object or error if creation failed.
+ * @returns {Promise<AzionDatabaseResponse<AzionDatabase>>} The created database object or error if creation failed.
  *
  * @example
  * const { data, error } = await createDatabase('my-new-database', { debug: true });
@@ -322,7 +314,10 @@ const executeDatabaseMethod = async (
  *  console.error(`Failed to create database: ${error.message}`);
  * }
  */
-const createDatabaseWrapper = async (name: string, options?: AzionClientOptions): Promise<AzionDatabaseResponse> =>
+const createDatabaseWrapper = async (
+  name: string,
+  options?: AzionClientOptions,
+): Promise<AzionDatabaseResponse<AzionDatabase>> =>
   await createDatabaseMethod(resolveToken(), name, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -330,7 +325,7 @@ const createDatabaseWrapper = async (name: string, options?: AzionClientOptions)
  *
  * @param {number} id - ID of the database to delete.
  * @param {AzionClientOptions} [options] - Optional parameters for the deletion.
- * @returns {Promise<AzionDatabaseResponse>} Object confirming deletion or error if deletion failed.
+ * @returns {Promise<AzionDatabaseResponse<{ id: number }>>} Object confirming deletion or error if deletion failed.
  *
  * @example
  * const { data, error } = await deleteDatabase(123, { debug: true });
@@ -340,7 +335,10 @@ const createDatabaseWrapper = async (name: string, options?: AzionClientOptions)
  * console.error(`Failed to delete database: ${error.message}`);
  *
  */
-const deleteDatabaseWrapper = (id: number, options?: AzionClientOptions): Promise<AzionDatabaseResponse> =>
+const deleteDatabaseWrapper = (
+  id: number,
+  options?: AzionClientOptions,
+): Promise<AzionDatabaseResponse<{ id: number }>> =>
   deleteDatabaseMethod(resolveToken(), id, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -348,7 +346,7 @@ const deleteDatabaseWrapper = (id: number, options?: AzionClientOptions): Promis
  *
  * @param {string} name - Name of the database to retrieve.
  * @param {AzionClientOptions} [options] - Optional parameters for the deletion.
- * @returns {Promise<AzionDatabaseResponse>} The retrieved database object or error if not found.
+ * @returns {Promise<AzionDatabaseResponse<AzionDatabase>>} The retrieved database object or error if not found.
  *
  * @example
  * const { data, error } = await getDatabase('my-db', { debug: true });
@@ -358,7 +356,10 @@ const deleteDatabaseWrapper = (id: number, options?: AzionClientOptions): Promis
  *  console.error(`Failed to retrieve database: ${error.message}`);
  * }
  */
-const getDatabaseWrapper = async (name: string, options?: AzionClientOptions): Promise<AzionDatabaseResponse> =>
+const getDatabaseWrapper = async (
+  name: string,
+  options?: AzionClientOptions,
+): Promise<AzionDatabaseResponse<AzionDatabase>> =>
   getDatabaseMethod(resolveToken(), name, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -366,13 +367,13 @@ const getDatabaseWrapper = async (name: string, options?: AzionClientOptions): P
  *
  * @param {Partial<AzionDatabaseCollectionOptions>} [params] - Optional parameters for filtering and pagination.
  * @param {AzionClientOptions} [options] - Optional parameters for the deletion.
- * @returns {Promise<AzionDatabaseResponse>} Array of database objects or error if retrieval failed.
+ * @returns {Promise<AzionDatabaseResponse<AzionDatabaseCollections>>} Array of database objects or error if retrieval failed.
  *
  * @example
- * const { data, error } = await getDatabases({ page: 1, page_size: 10 }, { debug: true });
- * if (data) {
- * console.log(`Retrieved ${data.length} databases`);
- * data.forEach(db => console.log(`- ${db.name} (ID: ${db.id})`));
+ * const { data: allDatabases, error } = await getDatabases({ page: 1, page_size: 10 }, { debug: true });
+ * if (allDatabases) {
+ * console.log(`Retrieved ${allDatabases.count} databases`);
+ * allDatabases.results.forEach(db => console.log(`- ${db.name} (ID: ${db.id})`));
  * } else {
  * console.error('Failed to retrieve databases', error);
  * }
@@ -381,7 +382,7 @@ const getDatabaseWrapper = async (name: string, options?: AzionClientOptions): P
 const getDatabasesWrapper = (
   params?: Partial<AzionDatabaseCollectionOptions>,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseResponse> =>
+): Promise<AzionDatabaseResponse<AzionDatabaseCollections>> =>
   getDatabasesMethod(resolveToken(), params, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -393,7 +394,7 @@ const getDatabasesWrapper = (
 const listTablesWrapper = async (
   databaseName: string,
   options?: AzionClientOptions,
-): Promise<AzionDatabaseQueryResponse> => {
+): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> => {
   return queryDatabaseMethod(resolveToken(), databaseName, ['PRAGMA table_list'], {
     ...options,
     debug: resolveDebug(options?.debug),
@@ -420,7 +421,7 @@ const useQuery = (
   name: string,
   statements: string[],
   options?: AzionClientOptions,
-): Promise<AzionDatabaseQueryResponse> =>
+): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
   queryDatabaseMethod(resolveToken(), name, statements, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -443,7 +444,7 @@ const useExecute = async (
   name: string,
   statements: string[],
   options?: AzionClientOptions,
-): Promise<AzionDatabaseQueryResponse> =>
+): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
   executeDatabaseMethod(resolveToken(), name, statements, { ...options, debug: resolveDebug(options?.debug) });
 
 /**
@@ -471,13 +472,13 @@ const client: CreateAzionSQLClient = (
   const debugValue = resolveDebug(config?.options?.debug);
 
   const client: AzionSQLClient = {
-    createDatabase: (name: string): Promise<AzionDatabaseResponse> =>
+    createDatabase: (name: string): Promise<AzionDatabaseResponse<AzionDatabase>> =>
       createDatabaseMethod(tokenValue, name, { ...config, debug: debugValue }),
-    deleteDatabase: (id: number): Promise<AzionDatabaseResponse> =>
+    deleteDatabase: (id: number): Promise<AzionDatabaseResponse<{ id: number }>> =>
       deleteDatabaseMethod(tokenValue, id, { ...config, debug: debugValue }),
-    getDatabase: (name: string): Promise<AzionDatabaseResponse> =>
+    getDatabase: (name: string): Promise<AzionDatabaseResponse<AzionDatabase>> =>
       getDatabaseMethod(tokenValue, name, { ...config, debug: debugValue }),
-    getDatabases: (params?: AzionDatabaseCollectionOptions): Promise<AzionDatabaseResponse> =>
+    getDatabases: (params?: AzionDatabaseCollectionOptions): Promise<AzionDatabaseResponse<AzionDatabaseCollections>> =>
       getDatabasesMethod(tokenValue, params, { ...config, debug: debugValue }),
   } as const;
 
@@ -489,7 +490,7 @@ export {
   deleteDatabaseWrapper as deleteDatabase,
   getDatabaseWrapper as getDatabase,
   getDatabasesWrapper as getDatabases,
-  listTablesWrapper as listTables,
+  listTablesWrapper as getTables,
   useExecute,
   useQuery,
 };

--- a/packages/sql/src/services/api/index.ts
+++ b/packages/sql/src/services/api/index.ts
@@ -96,6 +96,7 @@ const deleteEdgeDatabase = async (token: string, id: number, debug?: boolean): P
       };
     }
     return {
+      state: result.state,
       data: {
         id,
       },

--- a/packages/sql/src/services/api/types.ts
+++ b/packages/sql/src/services/api/types.ts
@@ -11,18 +11,24 @@ export interface ApiDatabaseResponse {
 }
 
 export interface ApiListDatabasesResponse {
-  count: number;
+  count?: number;
   links?: {
     first: string | null;
     last: string | null;
     next: string | null;
     prev: string | null;
   };
-  results: ApiDatabaseResponse[];
+  results?: ApiDatabaseResponse[];
+  error?: ApiError;
 }
 
+export type ApiError = {
+  message: string;
+  operation: string;
+};
+
 export interface ApiQueryExecutionResponse {
-  state: 'executed' | 'pending' | 'failed';
+  state?: 'executed' | 'pending' | 'failed';
   data?: {
     results: {
       columns: string[];
@@ -32,20 +38,17 @@ export interface ApiQueryExecutionResponse {
       query_duration_ms?: number;
     };
   }[];
-  error?: {
-    detail: string;
-  };
+  error?: ApiError;
 }
 
 export interface ApiCreateDatabaseResponse {
-  state: 'executed' | 'pending' | 'failed';
+  state?: 'executed' | 'pending' | 'failed';
   data?: ApiDatabaseResponse;
-  error?: {
-    detail: string;
-  };
+  error?: ApiError;
 }
 
 export interface ApiDeleteDatabaseResponse {
-  state: 'executed' | 'pending';
-  data: null;
+  state?: 'executed' | 'pending';
+  data?: { id: number };
+  error?: ApiError;
 }

--- a/packages/sql/src/services/index.ts
+++ b/packages/sql/src/services/index.ts
@@ -39,10 +39,11 @@ export const apiQuery = async (
     };
   }
 
-  const { data, error } = await postQueryEdgeDatabase(token, database.id, statements, options?.debug);
+  const { state, data, error } = await postQueryEdgeDatabase(token, database.id, statements, options?.debug);
 
   if (data && data.length > 0) {
     const resultStatements: AzionDatabaseQueryResponse = {
+      state,
       results: data.map((result, index) => {
         return {
           statement: statements[index]?.split(' ')[0],
@@ -80,6 +81,7 @@ export const runtimeQuery = async (
     };
     const data = await internalSql.mapperQuery(internalResult);
     if (data && data.length > 0) {
+      resultStatements.state = 'executed-runtime';
       resultStatements.results = data;
     }
     if (options?.debug) {

--- a/packages/sql/src/services/runtime/index.ts
+++ b/packages/sql/src/services/runtime/index.ts
@@ -1,5 +1,5 @@
 import { Azion } from 'azion/types';
-import { AzionClientOptions, NonSelectQueryResult, QueryResult } from '../../types';
+import { AzionClientOptions, QueryResult } from '../../types';
 
 export const getAzionSql = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,10 +18,8 @@ export class InternalAzionSql {
    * @param {Array<{ statement: string; result: Azion.Sql.Rows }>} resultRows - The result rows from the query.
    * @returns {Promise<Array<QueryResult | NonSelectQueryResult>>} The mapped query results.
    */
-  mapperQuery = async (
-    resultRows: { statement: string; result: Azion.Sql.Rows }[],
-  ): Promise<(QueryResult | NonSelectQueryResult)[]> => {
-    const resultStatements: QueryResult[] | NonSelectQueryResult[] = [];
+  mapperQuery = async (resultRows: { statement: string; result: Azion.Sql.Rows }[]): Promise<QueryResult[]> => {
+    const resultStatements: QueryResult[] = [];
     for (const row of resultRows) {
       const columns = row.result.columnCount();
       if (columns === 0) {

--- a/packages/sql/src/types.ts
+++ b/packages/sql/src/types.ts
@@ -79,6 +79,7 @@ export type QueryResult = {
 };
 
 export type AzionDatabaseQueryResponse = {
+  state?: 'pending' | 'failed' | 'executed' | 'executed-runtime';
   results?: QueryResult[];
   toObject: () => JsonObjectQueryExecutionResponse | null;
 };
@@ -95,6 +96,11 @@ export type AzionDatabaseCollectionOptions = {
 export type AzionDatabaseCollections = {
   databases?: AzionDatabase[];
   count?: number;
+};
+
+export type AzionDatabaseDeleteResponse = {
+  state: 'pending' | 'failed' | 'executed';
+  id: number;
 };
 
 export interface AzionSQLClient {
@@ -117,7 +123,7 @@ export interface AzionSQLClient {
    * Deletes a database by its ID.
    *
    * @param {number} id - ID of the database to delete.
-   * @returns {Promise<AzionDatabaseResponse<{ id: number }>>} Object confirming deletion or error if the operation failed.
+   * @returns {Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>>} Object confirming deletion or error if the operation failed.
    *
    * @example
    * const { data, error } = await sqlClient.deleteDatabase(123);
@@ -127,7 +133,7 @@ export interface AzionSQLClient {
    * console.error(`Failed to delete database: ${error.message}`);
    *
    */
-  deleteDatabase: (id: number) => Promise<AzionDatabaseResponse<{ id: number }>>;
+  deleteDatabase: (id: number) => Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>>;
   /**
    * Retrieves a database by its Name.
    *

--- a/packages/sql/src/utils/mappers/to-object.ts
+++ b/packages/sql/src/utils/mappers/to-object.ts
@@ -2,29 +2,22 @@
 import { AzionDatabaseQueryResponse } from '../../types';
 
 export type JsonObjectQueryExecutionResponse = {
-  state: 'executed' | 'pending' | 'executed-runtime' | 'failed';
-  data: {
+  results?: {
     statement?: string;
     rows: { [key: string]: any }[];
   }[];
-  info?: {
-    rowsRead?: number;
-    rowsWritten?: number;
-    durationMs?: number;
-  };
 };
 
-export const toObjectQueryExecutionResponse = ({ state, data }: AzionDatabaseQueryResponse) => {
+export const toObjectQueryExecutionResponse = ({ results }: AzionDatabaseQueryResponse) => {
   let transformedData: any = [];
-  if (data instanceof Array) {
-    if (data.length === 0) {
+  if (results instanceof Array) {
+    if (results.length === 0) {
       return {
-        state,
-        data: [],
+        results: [],
       };
     }
     let transformedRows: any = null;
-    transformedData = data?.map((item) => {
+    transformedData = results?.map((item) => {
       if (item?.rows) {
         transformedRows = item.rows.map((row) => {
           const obj: { [key: string]: any } = {};
@@ -43,7 +36,6 @@ export const toObjectQueryExecutionResponse = ({ state, data }: AzionDatabaseQue
     });
   }
   return {
-    state,
-    data: transformedData,
+    results: transformedData,
   };
 };

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -169,9 +169,9 @@ if (buckets) {
 **TypeScript:**
 
 ```typescript
-import { getBuckets, AzionStorageResponse, AzionListBuckets } from 'azion/storage';
+import { getBuckets, AzionStorageResponse, AzionBuckets } from 'azion/storage';
 
-const { data: buckets, error }: AzionStorageResponse<AzionListBuckets> = await getBuckets({
+const { data: buckets, error }: AzionStorageResponse<AzionBuckets> = await getBuckets({
   params: { page: 1, page_size: 10 },
 });
 if (buckets) {
@@ -316,9 +316,9 @@ if (object) {
 ```javascript
 import { getObjects } from 'azion/storage';
 
-const { data: objects, error } = await getObjects({ bucketName: 'my-bucket' });
-if (objects) {
-  console.log(`Retrieved ${objects.length} objects from the bucket`);
+const { data: objectsResult, error } = await getObjects({ bucketName: 'my-bucket' });
+if (objectsResult) {
+  console.log(`Retrieved ${objectsResult.count} objects from the bucket`);
 } else {
   console.error('Failed to retrieve objects', error);
 }
@@ -329,11 +329,11 @@ if (objects) {
 ```typescript
 import { getObjects, AzionBucketObject, AzionStorageResponse } from 'azion/storage';
 
-const { data: objects, error }: AzionStorageResponse<AzionBucketObject[]> = await getObjects({
+const { data: objectResult, error }: AzionStorageResponse<AzionBucketObjects> = await getObjects({
   bucketName: 'my-bucket',
 });
-if (objects) {
-  console.log(`Retrieved ${objects.length} objects from the bucket`);
+if (objectResult) {
+  console.log(`Retrieved ${objectResult.count} objects from the bucket`);
 } else {
   console.error('Failed to retrieve objects', error);
 }
@@ -451,7 +451,7 @@ import {
   AzionStorageResponse,
   AzionBucket,
   AzionBucketObject,
-  AzionListBuckets,
+  AzionBuckets,
 } from 'azion/storage';
 
 const client: StorageClient = createClient({ token: 'your-api-token', debug: true });
@@ -464,7 +464,7 @@ if (data) {
   console.log(`Bucket created with name: ${data.name}`);
 }
 
-const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.getBuckets();
+const { data: allBuckets }: AzionStorageResponse<AzionBuckets> = await client.getBuckets();
 if (allBuckets) {
   console.log(`Retrieved ${allBuckets.count} buckets`);
 }
@@ -530,7 +530,7 @@ Retrieves a list of buckets with optional filtering and pagination.
 
 **Returns:**
 
-- `Promise<AzionStorageResponse<AzionListBuckets>>` - Array of bucket objects or error.
+- `Promise<AzionStorageResponse<AzionBuckets>>` - Array of bucket objects or error.
 
 ### `getBucket`
 
@@ -599,7 +599,7 @@ Retrieves a list of objects in a specific bucket.
 
 **Returns:**
 
-- `Promise<AzionStorageResponse<AzionBucketObject[]>>` - Array of bucket objects or error.
+- `Promise<AzionStorageResponse<AzionBucketObjects>>` - Array of bucket objects or error.
 
 ### `updateObject`
 
@@ -655,7 +655,7 @@ Configuration options for the Storage client.
 
 An object with methods to interact with Storage.
 
-- `getBuckets: (options?: BucketCollectionOptions) => Promise<AzionStorageResponse<AzionListBuckets>>`
+- `getBuckets: (options?: BucketCollectionOptions) => Promise<AzionStorageResponse<AzionBuckets>>`
 - `createBucket: (name: string, edge_access: string) => Promise<AzionStorageResponse<AzionBucket>>`
 - `updateBucket: (name: string, edge_access: string) => Promise<AzionStorageResponse<AzionBucket>>`
 - `deleteBucket: (name: string) => Promise<AzionStorageResponse<AzionDeletedBucket>>`
@@ -675,7 +675,7 @@ The bucket object.
 - `name: string`
 - `edge_access?: string`
 - `state?: 'executed' | 'pending'`
-- `getObjects?: () => Promise<AzionStorageResponse<AzionBucketObject[]>>`
+- `getObjects?: () => Promise<AzionStorageResponse<AzionBucketObjects>>`
 - `getObjectByKey?: (objectKey: string) => Promise<AzionStorageResponse<AzionBucketObject>>`
 - `createObject?: (objectKey: string, file: string) => Promise<AzionStorageResponse<AzionBucketObject>>`
 - `updateObject?: (objectKey: string, file: string) => Promise<AzionStorageResponse<AzionBucketObject>>`

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -26,7 +26,7 @@ Azion Edge Storage Client provides a simple interface to interact with the Azion
   - [`createBucket`](#createbucket)
   - [`deleteBucket`](#deletebucket)
   - [`getBuckets`](#getbuckets)
-  - [`getBucket`](#getbucketbyname)
+  - [`getBucket`](#getbucket)
   - [`updateBucket`](#updatebucket)
   - [`createObject`](#createobject)
   - [`getObjectByKey`](#getobjectbykey)
@@ -37,6 +37,7 @@ Azion Edge Storage Client provides a simple interface to interact with the Azion
 - [Types](#types)
   - [`ClientConfig`](#clientconfig)
   - [`StorageClient`](#storageclient)
+  - [`AzionStorageResponse`](#azionbucketresponse)
   - [`Bucket`](#bucket)
   - [`BucketObject`](#bucketobject)
   - [`DeletedBucket`](#deletedbucket)
@@ -98,23 +99,27 @@ You can create a client instance with specific configurations.
 ```javascript
 import { createBucket } from 'azion/storage';
 
-const bucket = await createBucket({ name: 'my-new-bucket', edge_access: 'public' });
-if (bucket) {
-  console.log(`Bucket created with name: ${bucket.name}`);
+const { data, error } = await createBucket({ name: 'my-new-bucket', edge_access: 'public' });
+if (data) {
+  console.log(`Bucket created with name: ${data.name}`);
 } else {
-  console.error('Failed to create bucket');
+  console.error('Failed to create bucket', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { createBucket, AzionBucket } from 'azion/storage';
-const bucket: AzionBucket | null = await createBucket({ name: 'my-new-bucket', edge_access: 'public' });
-if (bucket) {
-  console.log(`Bucket created with name: ${bucket.name}`);
+import { createBucket } from 'azion/storage';
+import type { AzionStorageResponse, AzionBucket } from 'azion/storage';
+const { data, error }: AzionStorageResponse<AzionBucket> = await createBucket({
+  name: 'my-new-bucket',
+  edge_access: 'public',
+});
+if (data) {
+  console.log(`Bucket created with name: ${data.name}`);
 } else {
-  console.error('Failed to create bucket');
+  console.error('Failed to create bucket', error);
 }
 ```
 
@@ -125,24 +130,24 @@ if (bucket) {
 ```javascript
 import { deleteBucket } from 'azion/storage';
 
-const result = await deleteBucket({ name: 'my-bucket' });
-if (result) {
-  console.log(`Bucket ${result.name} deleted successfully`);
+const { data, error } = await deleteBucket({ name: 'my-bucket' });
+if (data) {
+  console.log(`Bucket ${data.name} deleted successfully`);
 } else {
-  console.error('Failed to delete bucket');
+  console.error('Failed to delete bucket', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { deleteBucket, AzionDeletedBucket } from 'azion/storage';
+import { deleteBucket, AzionDeletedBucket, AzionStorageResponse } from 'azion/storage';
 
-const result: AzionDeletedBucket | null = await deleteBucket({ name: 'my-bucket' });
-if (result) {
-  console.log(`Bucket ${result.name} deleted successfully`);
+const { data, error }: AzionStorageResponse<AzionDeletedBucket> = await deleteBucket({ name: 'my-bucket' });
+if (data) {
+  console.log(`Bucket ${data.name} deleted successfully`);
 } else {
-  console.error('Failed to delete bucket');
+  console.error('Failed to delete bucket', error);
 }
 ```
 
@@ -153,24 +158,26 @@ if (result) {
 ```javascript
 import { getBuckets } from 'azion/storage';
 
-const buckets = await getBuckets({ params: { page: 1, page_size: 10 } });
+const { data: buckets, error } = await getBuckets({ params: { page: 1, page_size: 10 } });
 if (buckets) {
-  console.log(`Retrieved ${buckets.length} buckets`);
+  console.log(`Retrieved ${buckets.count} buckets`);
 } else {
-  console.error('Failed to retrieve buckets');
+  console.error('Failed to retrieve buckets', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { getBuckets, AzionBucket } from 'azion/storage';
+import { getBuckets, AzionStorageResponse, AzionListBuckets } from 'azion/storage';
 
-const buckets: AzionBucket[] | null = await getBuckets({ params: { page: 1, page_size: 10 } });
+const { data: buckets, error }: AzionStorageResponse<AzionListBuckets> = await getBuckets({
+  params: { page: 1, page_size: 10 },
+});
 if (buckets) {
-  console.log(`Retrieved ${buckets.length} buckets`);
+  console.log(`Retrieved ${buckets.count} buckets`);
 } else {
-  console.error('Failed to retrieve buckets');
+  console.error('Failed to retrieve buckets', error);
 }
 ```
 
@@ -181,11 +188,11 @@ if (buckets) {
 ```javascript
 import { getBucket } from 'azion/storage';
 
-const bucket = await getBucket({ name: 'my-bucket' });
+const { data: bucket, error } = await getBucket({ name: 'my-bucket' });
 if (bucket) {
   console.log(`Retrieved bucket: ${bucket.name}`);
 } else {
-  console.error('Bucket not found');
+  console.error('Bucket not found', error);
 }
 ```
 
@@ -194,11 +201,11 @@ if (bucket) {
 ```typescript
 import { getBucket, AzionBucket } from 'azion/storage';
 
-const bucket: AzionBucket | null = await getBucket({ name: 'my-bucket' });
+const { data: bucket, error }: AzionStorageResponse<AzionBucket> = await getBucket({ name: 'my-bucket' });
 if (bucket) {
   console.log(`Retrieved bucket: ${bucket.name}`);
 } else {
-  console.error('Bucket not found');
+  console.error('Bucket not found', error);
 }
 ```
 
@@ -209,24 +216,27 @@ if (bucket) {
 ```javascript
 import { updateBucket } from 'azion/storage';
 
-const updatedBucket = await updateBucket({ name: 'my-bucket', edge_access: 'private' });
+const { data: updatedBucket, error } = await updateBucket({ name: 'my-bucket', edge_access: 'private' });
 if (updatedBucket) {
   console.log(`Bucket updated: ${updatedBucket.name}`);
 } else {
-  console.error('Failed to update bucket');
+  console.error('Failed to update bucket', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { updateBucket, AzionBucket } from 'azion/storage';
+import { updateBucket, AzionBucket, AzionStorageResponse } from 'azion/storage';
 
-const updatedBucket: AzionBucket | null = await updateBucket({ name: 'my-bucket', edge_access: 'private' });
+const { data: updatedBucket, error }: AzionStorageResponse<AzionBucket> | null = await updateBucket({
+  name: 'my-bucket',
+  edge_access: 'private',
+});
 if (updatedBucket) {
   console.log(`Bucket updated: ${updatedBucket.name}`);
 } else {
-  console.error('Failed to update bucket');
+  console.error('Failed to update bucket', error);
 }
 ```
 
@@ -237,21 +247,7 @@ if (updatedBucket) {
 ```javascript
 import { createObject } from 'azion/storage';
 
-const newObject = await createObject({ bucketName: 'my-bucket', key: 'new-file.txt', file: 'File content' });
-if (newObject) {
-  console.log(`Object created with key: ${newObject.key}`);
-  console.log(`Object content: ${newObject.content}`);
-} else {
-  console.error('Failed to create object');
-}
-```
-
-**TypeScript:**
-
-```typescript
-import { createObject, AzionBucketObject } from 'azion/storage';
-
-const newObject: AzionBucketObject | null = await createObject({
+const { data: newObject, error } = await createObject({
   bucketName: 'my-bucket',
   key: 'new-file.txt',
   file: 'File content',
@@ -260,7 +256,25 @@ if (newObject) {
   console.log(`Object created with key: ${newObject.key}`);
   console.log(`Object content: ${newObject.content}`);
 } else {
-  console.error('Failed to create object');
+  console.error('Failed to create object', error);
+}
+```
+
+**TypeScript:**
+
+```typescript
+import { createObject, AzionBucketObject, AzionStorageResponse } from 'azion/storage';
+
+const { data: newObject, error }: AzionStorageResponse<AzionBucketObject> = await createObject({
+  bucketName: 'my-bucket',
+  key: 'new-file.txt',
+  file: 'File content',
+});
+if (newObject) {
+  console.log(`Object created with key: ${newObject.key}`);
+  console.log(`Object content: ${newObject.content}`);
+} else {
+  console.error('Failed to create object', error);
 }
 ```
 
@@ -271,24 +285,27 @@ if (newObject) {
 ```javascript
 import { getObjectByKey } from 'azion/storage';
 
-const object = await getObjectByKey({ bucketName: 'my-bucket', key: 'file.txt' });
+const { data: object, error } = await getObjectByKey({ bucketName: 'my-bucket', key: 'file.txt' });
 if (object) {
   console.log(`Retrieved object: ${object.key}`);
 } else {
-  console.error('Object not found');
+  console.error('Object not found', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { getObjectByKey, AzionBucketObject } from 'azion/storage';
+import { getObjectByKey, AzionBucketObject, AzionStorageResponse } from 'azion/storage';
 
-const object: AzionBucketObject | null = await getObjectByKey({ bucketName: 'my-bucket', key: 'file.txt' });
+const { data: object, error }: AzionStorageResponse<AzionBucketObject> = await getObjectByKey({
+  bucketName: 'my-bucket',
+  key: 'file.txt',
+});
 if (object) {
   console.log(`Retrieved object: ${object.key}`);
 } else {
-  console.error('Object not found');
+  console.error('Object not found', error);
 }
 ```
 
@@ -299,24 +316,26 @@ if (object) {
 ```javascript
 import { getObjects } from 'azion/storage';
 
-const objects = await getObjects({ bucketName: 'my-bucket' });
+const { data: objects, error } = await getObjects({ bucketName: 'my-bucket' });
 if (objects) {
   console.log(`Retrieved ${objects.length} objects from the bucket`);
 } else {
-  console.error('Failed to retrieve objects');
+  console.error('Failed to retrieve objects', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { getObjects, AzionBucketObject } from 'azion/storage';
+import { getObjects, AzionBucketObject, AzionStorageResponse } from 'azion/storage';
 
-const objects: AzionBucketObject[] | null = await getObjects({ bucketName: 'my-bucket' });
+const { data: objects, error }: AzionStorageResponse<AzionBucketObject[]> = await getObjects({
+  bucketName: 'my-bucket',
+});
 if (objects) {
   console.log(`Retrieved ${objects.length} objects from the bucket`);
 } else {
-  console.error('Failed to retrieve objects');
+  console.error('Failed to retrieve objects', error);
 }
 ```
 
@@ -327,21 +346,7 @@ if (objects) {
 ```javascript
 import { updateObject } from 'azion/storage';
 
-const updatedObject = await updateObject({ bucketName: 'my-bucket', key: 'file.txt', file: 'Updated content' });
-if (updatedObject) {
-  console.log(`Object updated: ${updatedObject.key}`);
-  console.log(`New content: ${updatedObject.content}`);
-} else {
-  console.error('Failed to update object');
-}
-```
-
-**TypeScript:**
-
-```typescript
-import { updateObject, AzionBucketObject } from 'azion/storage';
-
-const updatedObject: AzionBucketObject | null = await updateObject({
+const { data: updatedObject, error } = await updateObject({
   bucketName: 'my-bucket',
   key: 'file.txt',
   file: 'Updated content',
@@ -350,7 +355,25 @@ if (updatedObject) {
   console.log(`Object updated: ${updatedObject.key}`);
   console.log(`New content: ${updatedObject.content}`);
 } else {
-  console.error('Failed to update object');
+  console.error('Failed to update object', error);
+}
+```
+
+**TypeScript:**
+
+```typescript
+import { updateObject, AzionBucketObject } from 'azion/storage';
+
+const { data: updatedObject, error }: AzionStorageResponse<AzionBucketObject> = await updateObject({
+  bucketName: 'my-bucket',
+  key: 'file.txt',
+  file: 'Updated content',
+});
+if (updatedObject) {
+  console.log(`Object updated: ${updatedObject.key}`);
+  console.log(`New content: ${updatedObject.content}`);
+} else {
+  console.error('Failed to update object', error);
 }
 ```
 
@@ -361,24 +384,27 @@ if (updatedObject) {
 ```javascript
 import { deleteObject } from 'azion/storage';
 
-const result = await deleteObject({ bucketName: 'my-bucket', key: 'file.txt' });
+const { data: result, error } = await deleteObject({ bucketName: 'my-bucket', key: 'file.txt' });
 if (result) {
   console.log(`Object ${result.key} deleted successfully`);
 } else {
-  console.error('Failed to delete object');
+  console.error('Failed to delete object', error);
 }
 ```
 
 **TypeScript:**
 
 ```typescript
-import { deleteObject, AzionDeletedBucketObject } from 'azion/storage';
+import { deleteObject, AzionDeletedBucketObject, AzionStorageResponse } from 'azion/storage';
 
-const result: AzionDeletedBucketObject | null = await deleteObject({ bucketName: 'my-bucket', key: 'file.txt' });
+const { data: result, error }: AzionStorageResponse<AzionDeletedBucketObject> = await deleteObject({
+  bucketName: 'my-bucket',
+  key: 'file.txt',
+});
 if (result) {
   console.log(`Object ${result.key} deleted successfully`);
 } else {
-  console.error('Failed to delete object');
+  console.error('Failed to delete object', error);
 }
 ```
 
@@ -391,45 +417,17 @@ import { createClient } from 'azion/storage';
 
 const client = createClient({ token: 'your-api-token', debug: true });
 
-const newBucket = await client.createBucket({ name: 'my-new-bucket', edge_access: 'public' });
-if (newBucket) {
-  console.log(`Bucket created with name: ${newBucket.name}`);
+const { data, error } = await client.createBucket({ name: 'my-new-bucket', edge_access: 'public' });
+if (data) {
+  console.log(`Bucket created with name: ${data.name}`);
 }
 
-const allBuckets = await client.getBuckets();
+const { data: allBuckets } = await client.getBuckets();
 if (allBuckets) {
-  console.log(`Retrieved ${allBuckets.length} buckets`);
+  console.log(`Retrieved ${allBuckets.count} buckets`);
 }
 
-const newObject = await client.createObject({ bucketName: 'my-new-bucket', key: 'new-file.txt', file: 'File content' });
-if (newObject) {
-  console.log(`Object created with key: ${newObject.key}`);
-}
-
-const queryResult = await newObject.updateObject({ key: 'new-file.txt', file: 'Updated content' });
-if (queryResult) {
-  console.log(`Object updated with key: ${queryResult.key}`);
-}
-```
-
-**TypeScript:**
-
-```typescript
-import { createClient, StorageClient, AzionBucket, AzionBucketObject } from 'azion/storage';
-
-const client: StorageClient = createClient({ token: 'your-api-token', debug: true });
-
-const newBucket: AzionBucket | null = await client.createBucket({ name: 'my-new-bucket', edge_access: 'public' });
-if (newBucket) {
-  console.log(`Bucket created with name: ${newBucket.name}`);
-}
-
-const allBuckets: AzionBucket[] | null = await client.getBuckets();
-if (allBuckets) {
-  console.log(`Retrieved ${allBuckets.length} buckets`);
-}
-
-const newObject: AzionBucketObject | null = await client.createObject({
+const { data: newObject } = await client.createObject({
   bucketName: 'my-new-bucket',
   key: 'new-file.txt',
   file: 'File content',
@@ -438,12 +436,276 @@ if (newObject) {
   console.log(`Object created with key: ${newObject.key}`);
 }
 
-const queryResult: AzionBucketObject | null = await client.updateObject({
+const { data: updateResult } = await newObject.updateObject({ key: 'new-file.txt', file: 'Updated content' });
+if (updateResult) {
+  console.log(`Object updated with key: ${updateResult.key}`);
+}
+```
+
+**TypeScript:**
+
+```typescript
+import {
+  createClient,
+  StorageClient,
+  AzionStorageResponse,
+  AzionBucket,
+  AzionBucketObject,
+  AzionListBuckets,
+} from 'azion/storage';
+
+const client: StorageClient = createClient({ token: 'your-api-token', debug: true });
+
+const { data, error }: AzionStorageResponse<AzionBucket> = await client.createBucket({
+  name: 'my-new-bucket',
+  edge_access: 'public',
+});
+if (data) {
+  console.log(`Bucket created with name: ${data.name}`);
+}
+
+const { data: allBuckets }: AzionStorageResponse<AzionListBuckets> = await client.getBuckets();
+if (allBuckets) {
+  console.log(`Retrieved ${allBuckets.count} buckets`);
+}
+
+const { data: newObject }: AzionStorageResponse<AzionBucketObject> = await client.createObject({
+  bucketName: 'my-new-bucket',
+  key: 'new-file.txt',
+  file: 'File content',
+});
+if (newObject) {
+  console.log(`Object created with key: ${newObject.key}`);
+}
+
+const { data: updateResult }: AzionStorageResponse<AzionBucketObject> = await client.updateObject({
   bucketName: 'my-new-bucket',
   key: 'new-file.txt',
   file: 'Updated content',
 });
-if (queryResult) {
-  console.log(`Object updated with key: ${queryResult.key}`);
+if (updateResult) {
+  console.log(`Object updated with key: ${updateResult.key}`);
 }
 ```
+
+## API Reference
+
+### `createBucket`
+
+Creates a new bucket.
+
+**Parameters:**
+
+- `name: string` - Name of the new bucket.
+- `edge_access: string` - Edge access configuration for the bucket.
+- `options?: AzionClientOptions` - Optional parameters for the request.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionBucket>>` - The created bucket object or error.
+
+### `deleteBucket`
+
+Deletes a bucket by its name.
+
+**Parameters:**
+
+- `name: string` - Name of the bucket to delete.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionDeletedBucket>>` - Object confirming deletion or error.
+
+### `getBuckets`
+
+Retrieves a list of buckets with optional filtering and pagination.
+
+**Parameters:**
+
+- `options?: AzionBucketCollectionOptions` - Optional parameters for filtering and pagination.
+  - `page?: number` - Page number for pagination.
+  - `page_size?: number` - Number of items per page.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionListBuckets>>` - Array of bucket objects or error.
+
+### `getBucket`
+
+Retrieves a bucket by its name.
+
+**Parameters:**
+
+- `name: string` - Name of the bucket to retrieve.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionBucket>>` - The retrieved bucket object or error if not found.
+
+### `updateBucket`
+
+Updates an existing bucket.
+
+**Parameters:**
+
+- `name: string` - Name of the bucket to update.
+- `edge_access: string` - New edge access configuration for the bucket.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionBucket>>` - The updated bucket object or error if update failed.
+
+### `createObject`
+
+Creates a new object in a specific bucket.
+
+**Parameters:**
+
+- `bucketName: string` - Name of the bucket to create the object in.
+- `objectKey: string` - Key (name) of the object to create.
+- `file: string` - Content of the file to upload.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionBucketObject | null>` - The created object or null if creation failed.
+
+### `getObjectByKey`
+
+Retrieves an object from a specific bucket by its key.
+
+**Parameters:**
+
+- `bucketName: string` - Name of the bucket containing the object.
+- `objectKey: string` - Key of the object to retrieve.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionBucketObject | null>` - The retrieved object or null if not found.
+
+### `getObjects`
+
+Retrieves a list of objects in a specific bucket.
+
+**Parameters:**
+
+- `bucketName: string` - Name of the bucket to retrieve objects from.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionBucketObject[]>>` - Array of bucket objects or error.
+
+### `updateObject`
+
+Updates an existing object in a specific bucket.
+
+**Parameters:**
+
+- `bucketName: string` - Name of the bucket containing the object.
+- `objectKey: string` - Key of the object to update.
+- `file: string` - New content of the file.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionBucketObject>>` - The updated object or error if update failed.
+
+### `deleteObject`
+
+Deletes an object from a specific bucket.
+
+**Parameters:**
+
+- `bucketName: string` - Name of the bucket containing the object.
+- `objectKey: string` - Key of the object to delete.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+**Returns:**
+
+- `Promise<AzionStorageResponse<AzionDeletedBucketObject>>` - Confirmation of deletion or error if deletion failed.
+
+### `createClient`
+
+Creates a Storage client with methods to interact with Azion Edge Storage.
+
+**Parameters:**
+
+- `config?: Partial<{ token: string; debug: boolean }>` - Configuration options for the Storage client.
+
+**Returns:**
+
+- `StorageClient` - An object with methods to interact with Storage.
+
+## Types
+
+### `ClientConfig`
+
+Configuration options for the Storage client.
+
+- `token?: string` - Your Azion API token.
+- `debug?: boolean` - Enable debug mode for detailed logging.
+
+### `StorageClient`
+
+An object with methods to interact with Storage.
+
+- `getBuckets: (options?: BucketCollectionOptions) => Promise<AzionStorageResponse<AzionListBuckets>>`
+- `createBucket: (name: string, edge_access: string) => Promise<AzionStorageResponse<AzionBucket>>`
+- `updateBucket: (name: string, edge_access: string) => Promise<AzionStorageResponse<AzionBucket>>`
+- `deleteBucket: (name: string) => Promise<AzionStorageResponse<AzionDeletedBucket>>`
+- `getBucket: (name: string) => Promise<AzionStorageResponse<AzionBucket>>`
+
+### `AzionStorageResponse<T>`
+
+The response object from a bucket operation.
+
+- `data?: T` - The data generic object.
+- `error?: { message: string; operation: string;}`
+
+### `AzionBucket`
+
+The bucket object.
+
+- `name: string`
+- `edge_access?: string`
+- `state?: 'executed' | 'pending'`
+- `getObjects?: () => Promise<AzionStorageResponse<AzionBucketObject[]>>`
+- `getObjectByKey?: (objectKey: string) => Promise<AzionStorageResponse<AzionBucketObject>>`
+- `createObject?: (objectKey: string, file: string) => Promise<AzionStorageResponse<AzionBucketObject>>`
+- `updateObject?: (objectKey: string, file: string) => Promise<AzionStorageResponse<AzionBucketObject>>`
+- `deleteObject?: (objectKey: string) => Promise<AzionStorageResponse<AzionDeletedBucketObject>>`
+
+### `AzionBucketObject`
+
+The bucket object.
+
+- `key: string`
+- `state?: 'executed' | 'pending'`
+- `size?: number`
+- `last_modified?: string`
+- `content_type?: string`
+- `content?: string`
+
+### `AzionDeletedBucket`
+
+The response object from a delete bucket request.
+
+- `name: string`
+- `state: 'executed' | 'pending'`
+
+### `AzionDeletedBucketObject`
+
+The response object from a delete object request.
+
+- `key: string`
+- `state: 'executed' | 'pending'`
+
+## Contributing
+
+Feel free to submit issues or pull requests to improve the functionality or documentation.

--- a/packages/storage/src/index.test.ts
+++ b/packages/storage/src/index.test.ts
@@ -55,15 +55,17 @@ describe('Storage Module', () => {
       (services.postBucket as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await createBucket({ name: 'test-bucket', edge_access: 'public', options: { debug } });
-      expect(result).toEqual(expect.objectContaining({ name: 'test-bucket', edge_access: 'public' }));
+      expect(result.data).toEqual(expect.objectContaining({ name: 'test-bucket', edge_access: 'public' }));
       expect(services.postBucket).toHaveBeenCalledWith(mockToken, 'test-bucket', 'public', debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.postBucket as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.postBucket as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'create bucket' },
+      });
 
       const result = await createBucket({ name: 'test-bucket', edge_access: 'public', options: { debug } });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'token invalid', operation: 'create bucket' } });
     });
   });
 
@@ -73,15 +75,17 @@ describe('Storage Module', () => {
       (services.deleteBucket as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await deleteBucket({ name: 'test-bucket', options: { debug } });
-      expect(result).toEqual({ name: 'test-bucket', state: 'success' });
+      expect(result.data).toEqual({ name: 'test-bucket', state: 'success' });
       expect(services.deleteBucket).toHaveBeenCalledWith(mockToken, 'test-bucket', debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.deleteBucket as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.deleteBucket as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'delete bucket' },
+      });
 
       const result = await deleteBucket({ name: 'test-bucket', options: { debug } });
-      expect(result).toBeNull();
+      expect(result.error).toEqual({ message: 'token invalid', operation: 'delete bucket' });
     });
   });
 
@@ -91,16 +95,18 @@ describe('Storage Module', () => {
       (services.getBuckets as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getBuckets({ params: { page: 1, page_size: 10 }, options: { debug } });
-      expect(result).toHaveLength(2);
-      expect(result![0]).toHaveProperty('name', 'bucket1');
+      expect(result.data?.buckets).toHaveLength(2);
+      expect(result.data?.buckets[0]).toHaveProperty('name', 'bucket1');
       expect(services.getBuckets).toHaveBeenCalledWith(mockToken, { page: 1, page_size: 10 }, debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.getBuckets as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.getBuckets as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'get buckets' },
+      });
 
       const result = await getBuckets({ params: { page: 1, page_size: 10 }, options: { debug } });
-      expect(result).toBeNull();
+      expect(result.error).toEqual({ message: 'token invalid', operation: 'get buckets' });
     });
   });
 
@@ -110,16 +116,16 @@ describe('Storage Module', () => {
       (services.getBuckets as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getBucket({ name: 'test-bucket', options: { debug } });
-      expect(result).toEqual(expect.objectContaining({ name: 'test-bucket', edge_access: 'public' }));
+      expect(result.data).toEqual(expect.objectContaining({ name: 'test-bucket', edge_access: 'public' }));
       expect(services.getBuckets).toHaveBeenCalledWith(mockToken, { page_size: 1000000 }, debug);
     });
 
-    it('should return null if bucket is not found', async () => {
+    it('should return error if bucket is not found', async () => {
       const mockResponse = { results: [] };
       (services.getBuckets as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getBucket({ name: 'non-existent-bucket', options: { debug } });
-      expect(result).toBeNull();
+      expect(result.error).toEqual({ message: 'Bucket not found', operation: 'get bucket' });
     });
   });
 
@@ -129,15 +135,17 @@ describe('Storage Module', () => {
       (services.patchBucket as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await updateBucket({ name: 'test-bucket', edge_access: 'private', options: { debug } });
-      expect(result).toEqual(expect.objectContaining({ name: 'test-bucket', edge_access: 'private' }));
+      expect(result.data).toEqual(expect.objectContaining({ name: 'test-bucket', edge_access: 'private' }));
       expect(services.patchBucket).toHaveBeenCalledWith(mockToken, 'test-bucket', 'private', debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.patchBucket as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.patchBucket as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'update bucket' },
+      });
 
       const result = await updateBucket({ name: 'test-bucket', edge_access: 'private', options: { debug } });
-      expect(result).toBeNull();
+      expect(result.error).toEqual({ message: 'token invalid', operation: 'update bucket' });
     });
   });
 
@@ -152,12 +160,14 @@ describe('Storage Module', () => {
         content: 'file-content',
         options: { debug },
       });
-      expect(result).toEqual({ key: 'test-object', content: 'file-content', state: 'success' });
+      expect(result.data).toEqual({ key: 'test-object', content: 'file-content', state: 'success' });
       expect(services.postObject).toHaveBeenCalledWith(mockToken, 'test-bucket', 'test-object', 'file-content', debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.postObject as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.postObject as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'create object' },
+      });
 
       const result = await createObject({
         bucket: 'test-bucket',
@@ -165,43 +175,47 @@ describe('Storage Module', () => {
         content: 'file-content',
         options: { debug },
       });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'token invalid', operation: 'create object' } });
     });
   });
 
   describe('deleteObject', () => {
     it('should successfully delete an object', async () => {
-      const mockResponse = { state: 'success' };
+      const mockResponse = { data: { state: 'success' } };
       (services.deleteObject as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await deleteObject({ bucket: 'test-bucket', key: 'test-object', options: { debug } });
-      expect(result).toEqual({ key: 'test-object', state: 'success' });
+      expect(result.data).toEqual({ key: 'test-object' });
       expect(services.deleteObject).toHaveBeenCalledWith(mockToken, 'test-bucket', 'test-object', debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.deleteObject as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.deleteObject as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'delete object' },
+      });
 
       const result = await deleteObject({ bucket: 'test-bucket', key: 'test-object', options: { debug } });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'token invalid', operation: 'delete object' } });
     });
   });
 
   describe('getObjectByKey', () => {
     it('should successfully get an object by key', async () => {
-      const mockResponse = 'file-content';
+      const mockResponse = { data: 'file-content' };
       (services.getObjectByKey as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getObjectByKey({ bucket: 'test-bucket', key: 'test-object', options: { debug } });
-      expect(result).toEqual({ key: 'test-object', content: 'file-content' });
+      expect(result.data).toEqual({ key: 'test-object', content: 'file-content' });
       expect(services.getObjectByKey).toHaveBeenCalledWith(mockToken, 'test-bucket', 'test-object', debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.getObjectByKey as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.getObjectByKey as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'get object by key' },
+      });
 
       const result = await getObjectByKey({ bucket: 'test-bucket', key: 'test-object', options: { debug } });
-      expect(result).toBeNull();
+      expect(result.error).toEqual({ message: 'token invalid', operation: 'get object by key' });
     });
   });
 
@@ -216,16 +230,18 @@ describe('Storage Module', () => {
       (services.getObjects as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getObjects({ bucket: 'test-bucket', params: { max_object_count: 50 }, options: { debug } });
-      expect(result).toHaveLength(2);
-      expect(result![0]).toEqual(expect.objectContaining({ key: 'object1' }));
+      expect(result.data).toHaveLength(2);
+      expect(result.data![0]).toEqual(expect.objectContaining({ key: 'object1' }));
       expect(services.getObjects).toHaveBeenCalledWith(mockToken, 'test-bucket', { max_object_count: 50 }, debug);
     });
 
-    it('should return null on failure', async () => {
-      (services.getObjects as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.getObjects as jest.Mock).mockResolvedValue({
+        error: { message: 'token invalid', operation: 'get objects' },
+      });
 
       const result = await getObjects({ bucket: 'test-bucket', params: { max_object_count: 50 }, options: { debug } });
-      expect(result).toBeNull();
+      expect(result.error).toEqual({ message: 'token invalid', operation: 'get objects' });
     });
   });
 
@@ -240,7 +256,7 @@ describe('Storage Module', () => {
         content: 'updated-content',
         options: { debug },
       });
-      expect(result).toEqual({ key: 'test-object', content: 'updated-content', state: 'success' });
+      expect(result.data).toEqual({ key: 'test-object', content: 'updated-content', state: 'success' });
       expect(services.putObject).toHaveBeenCalledWith(
         mockToken,
         'test-bucket',
@@ -250,8 +266,10 @@ describe('Storage Module', () => {
       );
     });
 
-    it('should return null on failure', async () => {
-      (services.putObject as jest.Mock).mockResolvedValue(null);
+    it('should return error on failure', async () => {
+      (services.putObject as jest.Mock).mockResolvedValue({
+        error: { message: 'invalid token', operation: 'update object' },
+      });
 
       const result = await updateObject({
         bucket: 'test-bucket',
@@ -259,7 +277,7 @@ describe('Storage Module', () => {
         content: 'updated-content',
         options: { debug },
       });
-      expect(result).toBeNull();
+      expect(result).toEqual({ error: { message: 'invalid token', operation: 'update object' } });
     });
   });
 

--- a/packages/storage/src/index.test.ts
+++ b/packages/storage/src/index.test.ts
@@ -230,8 +230,8 @@ describe('Storage Module', () => {
       (services.getObjects as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getObjects({ bucket: 'test-bucket', params: { max_object_count: 50 }, options: { debug } });
-      expect(result.data).toHaveLength(2);
-      expect(result.data![0]).toEqual(expect.objectContaining({ key: 'object1' }));
+      expect(result.data?.objects).toHaveLength(2);
+      expect(result.data?.objects![0]).toEqual(expect.objectContaining({ key: 'object1' }));
       expect(services.getObjects).toHaveBeenCalledWith(mockToken, 'test-bucket', { max_object_count: 50 }, debug);
     });
 

--- a/packages/storage/src/services/api/types.d.ts
+++ b/packages/storage/src/services/api/types.d.ts
@@ -3,47 +3,67 @@ export interface ApiBucket {
   edge_access: string;
 }
 
+export type ApiError = {
+  message: string;
+  operation: string;
+};
+
+export interface ApiGetBucket {
+  data?: {
+    name: string;
+    edge_access: string;
+  };
+  error?: ApiError;
+}
+
 export interface ApiListBucketsResponse {
-  links: {
+  links?: {
     next: string | null;
     previous: string | null;
   };
-  count: number;
-  results: ApiBucket[];
+  count?: number;
+  results?: ApiBucket[];
+  error?: ApiError;
 }
 
 export interface ApiCreateBucketResponse {
-  state: 'executed' | 'pending';
-  data: ApiBucket;
+  state?: 'executed' | 'pending';
+  data?: ApiBucket;
+  error?: ApiError;
 }
 
 export interface ApiEditBucketResponse {
-  state: 'executed' | 'pending';
-  data: ApiBucket;
+  state?: 'executed' | 'pending';
+  data?: ApiBucket;
+  error?: ApiError;
 }
 
 export interface ApiDeleteBucketResponse {
-  state: 'executed' | 'pending';
-  data: Bucket;
+  state?: 'executed' | 'pending';
+  data?: Bucket;
+  error?: ApiError;
 }
 
 export interface ApiListObjectsResponse {
-  continuation_token: string | null;
-  results: BucketObject[];
+  continuation_token?: string | null;
+  results?: BucketObject[];
+  error?: ApiError;
 }
 
 export interface ApiCreateObjectResponse {
-  state: 'executed' | 'pending';
-  data: {
+  state?: 'executed' | 'pending';
+  data?: {
     object_key: string;
   };
+  error?: ApiError;
 }
 
 export interface ApiDeleteObjectResponse {
-  state: 'executed' | 'pending';
-  data: {
+  state?: 'executed' | 'pending';
+  data?: {
     object_key: string;
   };
+  error?: ApiError;
 }
 
 export interface ApiUpdateObjectResponse {

--- a/packages/storage/src/services/api/types.d.ts
+++ b/packages/storage/src/services/api/types.d.ts
@@ -1,3 +1,9 @@
+export type ApiBucketObject = {
+  key: string;
+  last_modified: string;
+  size: number;
+};
+
 export interface ApiBucket {
   name: string;
   edge_access: string;
@@ -40,13 +46,13 @@ export interface ApiEditBucketResponse {
 
 export interface ApiDeleteBucketResponse {
   state?: 'executed' | 'pending';
-  data?: Bucket;
+  data?: ApiBucket;
   error?: ApiError;
 }
 
 export interface ApiListObjectsResponse {
   continuation_token?: string | null;
-  results?: BucketObject[];
+  results?: ApiBucketObject[];
   error?: ApiError;
 }
 

--- a/packages/storage/src/services/runtime/index.ts
+++ b/packages/storage/src/services/runtime/index.ts
@@ -2,6 +2,7 @@ import { Azion } from 'azion/types';
 import {
   AzionBucket,
   AzionBucketObject,
+  AzionBucketObjects,
   AzionDeletedBucketObject,
   AzionObjectCollectionParams,
   AzionStorageResponse,
@@ -75,13 +76,13 @@ export class InternalStorageClient implements AzionBucket {
    *
    * @param {Object} params - Parameters for object collection.
    * @param {AzionObjectCollectionParams} [params.params] - Parameters for object collection.
-   * @returns {Promise<AzionStorageResponse<AzionBucketObject[]>>} The list of objects or error message.
+   * @returns {Promise<AzionStorageResponse<AzionBucketObjects>>} The list of objects or error message.
    */
   async getObjects({
     params,
   }: {
     params?: AzionObjectCollectionParams;
-  }): Promise<AzionStorageResponse<AzionBucketObject[]>> {
+  }): Promise<AzionStorageResponse<AzionBucketObjects>> {
     this.initializeStorage(this.name);
     try {
       const objectList = await retryWithBackoff(() => this.storage!.list());
@@ -96,7 +97,10 @@ export class InternalStorageClient implements AzionBucket {
         }),
       );
       return {
-        data: objects,
+        data: {
+          objects,
+          count: objects.length,
+        },
       };
     } catch (error) {
       if (this.debug) console.error('Error getting objects:', error);

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,4 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/no-namespace
+
+export type AzionStorageResponse<T> = {
+  data?: T;
+  error?: {
+    message: string;
+    operation: string;
+  };
+};
+
 /**
  * Represents an Azion storage bucket with methods to interact with objects.
  *
@@ -18,24 +27,24 @@ export interface AzionBucket {
    *
    * @param {Object} params - Parameters for retrieving objects.
    * @param {AzionObjectCollectionParams} params.params - Options for filtering and pagination.
-   * @returns {Promise<AzionBucketObject[] | null>} A promise that resolves to an array of bucket objects or null.
+   * @returns {Promise<AzionStorageResponse<AzionBucketObject[]>>} A promise that resolves to an array of bucket objects or error message.
    *
    * @example
-   * const objects = await bucket.getObjects({ params: { max_object_count: 100 } });
+   * const { data: objects, error } = await bucket.getObjects({ params: { max_object_count: 100 } });
    */
-  getObjects: (params: { params: AzionObjectCollectionParams }) => Promise<AzionBucketObject[] | null>;
+  getObjects: (params: { params: AzionObjectCollectionParams }) => Promise<AzionStorageResponse<AzionBucketObject[]>>;
 
   /**
    * Retrieves a specific object from the bucket by its key.
    *
    * @param {Object} params - Parameters for retrieving the object.
    * @param {string} params.key - The key of the object to retrieve.
-   * @returns {Promise<AzionBucketObject | null>} A promise that resolves to the bucket object or null if not found.
+   * @returns {Promise<AzionStorageResponse<AzionBucketObject>>} A promise that resolves to the bucket object or error message.
    *
    * @example
-   * const object = await bucket.getObjectByKey({ key: 'example.txt' });
+   * const { data: object } = await bucket.getObjectByKey({ key: 'example.txt' });
    */
-  getObjectByKey: (params: { key: string }) => Promise<AzionBucketObject | null>;
+  getObjectByKey: (params: { key: string }) => Promise<AzionStorageResponse<AzionBucketObject>>;
 
   /**
    * Creates a new object in the bucket.
@@ -45,10 +54,10 @@ export interface AzionBucket {
    * @param {string} params.content - The content of the new object.
    * @param {Object} [params.options] - Additional options for the object.
    * @param {string} [params.options.content_type] - The content type of the object.
-   * @returns {Promise<AzionBucketObject | null>} A promise that resolves to the created bucket object or null if creation failed.
+   * @returns {Promise<AzionStorageResponse<AzionBucketObject>>} A promise that resolves to the created bucket object or error message.
    *
    * @example
-   * const newObject = await bucket.createObject({
+   * const { data: newObject } = await bucket.createObject({
    *   key: 'new-file.txt',
    *   content: 'Hello, World!',
    *   options: { content_type: 'text/plain' }
@@ -58,7 +67,7 @@ export interface AzionBucket {
     key: string;
     content: string;
     options?: { content_type?: string };
-  }) => Promise<AzionBucketObject | null>;
+  }) => Promise<AzionStorageResponse<AzionBucketObject>>;
 
   /**
    * Updates an existing object in the bucket.
@@ -68,10 +77,10 @@ export interface AzionBucket {
    * @param {string} params.content - The new content for the object.
    * @param {Object} [params.options] - Additional options for the object.
    * @param {string} [params.options.content_type] - The new content type for the object.
-   * @returns {Promise<AzionBucketObject | null>} A promise that resolves to the updated bucket object or null if update failed.
+   * @returns {Promise<AzionStorageResponse<AzionBucketObject>>} A promise that resolves to the updated bucket object or error message.
    *
    * @example
-   * const updatedObject = await bucket.updateObject({
+   * const { data: updatedObject } = await bucket.updateObject({
    *   key: 'existing-file.txt',
    *   content: 'Updated content',
    *   options: { content_type: 'text/plain' }
@@ -81,19 +90,19 @@ export interface AzionBucket {
     key: string;
     content: string;
     options?: { content_type?: string };
-  }) => Promise<AzionBucketObject | null>;
+  }) => Promise<AzionStorageResponse<AzionBucketObject>>;
 
   /**
    * Deletes an object from the bucket.
    *
    * @param {Object} params - Parameters for deleting the object.
    * @param {string} params.key - The key of the object to delete.
-   * @returns {Promise<AzionDeletedBucketObject | null>} A promise that resolves to the deleted bucket object or null if deletion failed.
+   * @returns {Promise<AzionStorageResponse<AzionDeletedBucketObject>>} A promise that resolves to the deleted bucket object or error if deletion failed.
    *
    * @example
-   * const deletedObject = await bucket.deleteObject({ key: 'file-to-delete.txt' });
+   * const { data: deletedObject, error } = await bucket.deleteObject({ key: 'file-to-delete.txt' });
    */
-  deleteObject: (params: { key: string }) => Promise<AzionDeletedBucketObject | null>;
+  deleteObject: (params: { key: string }) => Promise<AzionStorageResponse<AzionDeletedBucketObject>>;
 }
 
 export interface AzionBucketObject {
@@ -115,43 +124,50 @@ export interface AzionDeletedBucket {
   state?: 'executed' | 'executed-runtime' | 'pending';
 }
 
+export interface AzionListBuckets {
+  buckets: AzionBucket[];
+  count: number;
+}
+
 export interface AzionStorageClient {
   /**
    * Retrieves a list of buckets with optional filtering and pagination.
    * @param {Object} params - Parameters for retrieving buckets.
    * @param {AzionBucketCollectionParams} [params.params] - Optional parameters for filtering and pagination.
-   * @returns {Promise<AzionBucket[] | null>} Array of buckets or null if retrieval failed.
+   * @returns {Promise<AzionStorageResponse<AzionListBuckets>>} Array of buckets or error message.
    */
-  getBuckets: (params?: { params?: AzionBucketCollectionParams }) => Promise<AzionBucket[] | null>;
+  getBuckets: (params?: { params?: AzionBucketCollectionParams }) => Promise<AzionStorageResponse<AzionListBuckets>>;
   /**
    * Creates a new bucket.
    * @param {Object} params - Parameters for creating a bucket.
    * @param {string} params.name - Name of the new bucket.
    * @param {string} params.edge_access - Edge access configuration for the bucket.
-   * @returns {Promise<AzionBucket | null>} The created bucket or null if creation failed.
+   * @returns {Promise<AzionStorageResponse>} The created bucket or error message.
    */
-  createBucket: (params: { name: string; edge_access: string }) => Promise<AzionBucket | null>;
+  createBucket: (params: { name: string; edge_access: string }) => Promise<AzionStorageResponse<AzionBucket>>;
+
+  /**
+   * Updates a bucket by its name.
+   * @param {Object} params - Parameters for updating a bucket.
+   * @param {string} params.name - Name of the bucket to update.
+   * @param {string} params.edge_access - New edge access configuration for the bucket.
+   * @returns {Promise<AzionStorageResponse<AzionBucket>>} The updated bucket or error message.
+   */
+  updateBucket: (params: { name: string; edge_access: string }) => Promise<AzionStorageResponse<AzionBucket>>;
   /**
    * Deletes a bucket by its name.
    * @param {Object} params - Parameters for deleting a bucket.
    * @param {string} params.name - Name of the bucket to delete.
-   * @returns {Promise<AzionDeletedBucket | null>} Confirmation of deletion or null if deletion failed.
+   * @returns {Promise<AzionStorageResponse<AzionDeletedBucket>>} Confirmation of deletion or error message.
    */
-  updateBucket: (params: { name: string; edge_access: string }) => Promise<AzionBucket | null>;
-  /**
-   * Deletes a bucket by its name.
-   * @param {Object} params - Parameters for deleting a bucket.
-   * @param {string} params.name - Name of the bucket to delete.
-   * @returns {Promise<AzionDeletedBucket | null>} Confirmation of deletion or null if deletion failed.
-   */
-  deleteBucket: (params: { name: string }) => Promise<AzionDeletedBucket | null>;
+  deleteBucket: (params: { name: string }) => Promise<AzionStorageResponse<AzionDeletedBucket>>;
   /**
    * Retrieves a bucket by its name.
    * @param {Object} params - Parameters for retrieving a bucket.
    * @param {string} params.name - Name of the bucket to retrieve.
-   * @returns {Promise<AzionBucket | null>} The retrieved bucket or null if not found.
+   * @returns {Promise<AzionStorageResponse<AzionBucket>>} The retrieved bucket or error message.
    */
-  getBucket: (params: { name: string }) => Promise<AzionBucket | null>;
+  getBucket: (params: { name: string }) => Promise<AzionStorageResponse<AzionBucket>>;
 }
 
 export type AzionBucketCollectionParams = {

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -27,12 +27,12 @@ export interface AzionBucket {
    *
    * @param {Object} params - Parameters for retrieving objects.
    * @param {AzionObjectCollectionParams} params.params - Options for filtering and pagination.
-   * @returns {Promise<AzionStorageResponse<AzionBucketObject[]>>} A promise that resolves to an array of bucket objects or error message.
+   * @returns {Promise<AzionStorageResponse<AzionBucketObjects>>} A promise that resolves to an array of bucket objects or error message.
    *
    * @example
    * const { data: objects, error } = await bucket.getObjects({ params: { max_object_count: 100 } });
    */
-  getObjects: (params: { params: AzionObjectCollectionParams }) => Promise<AzionStorageResponse<AzionBucketObject[]>>;
+  getObjects: (params: { params: AzionObjectCollectionParams }) => Promise<AzionStorageResponse<AzionBucketObjects>>;
 
   /**
    * Retrieves a specific object from the bucket by its key.
@@ -114,6 +114,11 @@ export interface AzionBucketObject {
   content?: string;
 }
 
+export interface AzionBucketObjects {
+  objects: AzionBucketObject[];
+  count: number;
+}
+
 export interface AzionDeletedBucketObject {
   key: string;
   state?: 'executed' | 'executed-runtime' | 'pending';
@@ -124,7 +129,7 @@ export interface AzionDeletedBucket {
   state?: 'executed' | 'executed-runtime' | 'pending';
 }
 
-export interface AzionListBuckets {
+export interface AzionBuckets {
   buckets: AzionBucket[];
   count: number;
 }
@@ -134,9 +139,9 @@ export interface AzionStorageClient {
    * Retrieves a list of buckets with optional filtering and pagination.
    * @param {Object} params - Parameters for retrieving buckets.
    * @param {AzionBucketCollectionParams} [params.params] - Optional parameters for filtering and pagination.
-   * @returns {Promise<AzionStorageResponse<AzionListBuckets>>} Array of buckets or error message.
+   * @returns {Promise<AzionStorageResponse<AzionBuckets>>} Array of buckets or error message.
    */
-  getBuckets: (params?: { params?: AzionBucketCollectionParams }) => Promise<AzionStorageResponse<AzionListBuckets>>;
+  getBuckets: (params?: { params?: AzionBucketCollectionParams }) => Promise<AzionStorageResponse<AzionBuckets>>;
   /**
    * Creates a new bucket.
    * @param {Object} params - Parameters for creating a bucket.


### PR DESCRIPTION
### Updating function returns

Updated the return of the azion/storage, azion/sql and azion/purge functions to the standard { data, error }.

Example:

```js
import { createBucket } from 'azion/storage';

const { data, error } = await createBucket({ name: 'my-new-bucket', edge_access: 'read_write' });
if (data) {
  console.log(`Bucket created with name: ${data.name}`);
} else {
  console.error('Failed to create bucket', error);
}
```