### PR TITLE
feat: add convert json config to config object

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 import createAzionApplicationClient, { AzionApplicationsClient } from 'azion/applications';
-import { defineConfig, processConfig } from 'azion/config';
+import { convertJsonConfigToObject, defineConfig, processConfig } from 'azion/config';
 import createDomainsClient, { AzionDomainsClient } from 'azion/domains';
 import createPurgeClient, { AzionPurgeClient } from 'azion/purge';
 import createSqlClient, { AzionSQLClient } from 'azion/sql';
@@ -78,7 +78,7 @@ function createClient({ token, options }: AzionClientConfig = {}): AzionClient {
   return client;
 }
 
-export { createClient, defineConfig, processConfig };
+export { convertJsonConfigToObject, createClient, defineConfig, processConfig };
 
 export default createClient;
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-import { processConfig, validateConfig } from './processConfig/index';
+import { convertJsonConfigToObject, processConfig, validateConfig } from './processConfig/index';
 import { AzionConfig } from './types';
 
 /**
@@ -211,6 +211,6 @@ function defineConfig(config: AzionConfig): AzionConfig {
   return config;
 }
 
-export { defineConfig, processConfig };
+export { convertJsonConfigToObject, defineConfig, processConfig };
 
 export type * from './types';

--- a/packages/config/src/processConfig/helpers/behaviors.ts
+++ b/packages/config/src/processConfig/helpers/behaviors.ts
@@ -209,3 +209,162 @@ export const responseBehaviors = {
   },
   // Adicione mais comportamentos conforme necessário
 };
+
+export const revertRequestBehaviors = {
+  set_origin: {
+    transform: (value: any, payloadCDN: any) => {
+      const origin = payloadCDN.origin.find((o: any) => o.name === value);
+      if (!origin) {
+        throw new Error(`Rule setOrigin name '${value.name}' not found in the origin settings`);
+      }
+      return {
+        setOrigin: {
+          name: value,
+          type: origin.type,
+        },
+      };
+    },
+  },
+  rewrite_request: {
+    transform: (value: any) => {
+      return {
+        rewrite: value,
+      };
+    },
+  },
+  deliver: {
+    transform: () => ({
+      deliver: true,
+    }),
+  },
+  add_request_cookie: {
+    transform: (value: any) => ({
+      setCookie: value,
+    }),
+  },
+  add_request_header: {
+    transform: (value: any) => ({
+      setHeaders: value.split(','),
+    }),
+  },
+  set_cache_policy: {
+    transform: (value: any) => {
+      if (typeof value === 'string') {
+        return {
+          setCache: value,
+        };
+      }
+      if (typeof value === 'object') {
+        const cacheSetting = {
+          name: value.name,
+          ...value,
+        };
+        return {
+          setCache: cacheSetting,
+        };
+      }
+      return undefined;
+    },
+  },
+  forward_cookies: {
+    transform: () => {
+      return {
+        forwardCookies: true,
+      };
+    },
+  },
+  run_function: {
+    transform: (value: any) => ({
+      runFunction: {
+        path: value,
+      },
+    }),
+  },
+  enable_gzip: {
+    transform: () => {
+      return {
+        enableGZIP: true,
+      };
+    },
+  },
+  bypass_cache_phase: {
+    transform: () => {
+      return {
+        bypassCache: true,
+      };
+    },
+  },
+  redirect_http_to_https: {
+    transform: () => {
+      return {
+        httpToHttps: true,
+      };
+    },
+  },
+  redirect_to_301: {
+    transform: (value: any) => ({
+      redirectTo301: value,
+    }),
+  },
+  redirect_to_302: {
+    transform: (value: any) => ({
+      redirectTo302: value,
+    }),
+  },
+  capture_match_groups: {
+    transform: (value: any) => ({
+      capture: {
+        match: value.regex,
+        captured: value.captured_array,
+        subject: value.subject,
+      },
+    }),
+  },
+};
+
+export const revertResponseBehaviors = {
+  set_cookie: {
+    transform: (value: any) => ({
+      setCookie: value,
+    }),
+  },
+  add_response_header: {
+    transform: (value: any) => ({
+      setHeaders: value.split(','),
+    }),
+  },
+  enable_gzip: {
+    transform: () => {
+      return {
+        enableGZIP: true,
+      };
+    },
+  },
+  filter_response_cookie: {
+    transform: (value: any) => ({
+      filterCookie: value,
+    }),
+  },
+  filter_response_header: {
+    transform: (value: any) => ({
+      filterHeader: value,
+    }),
+  },
+  run_function: {
+    transform: (value: any) => ({
+      runFunction: {
+        path: value,
+      },
+    }),
+  },
+  redirect_to_301: {
+    transform: (value: any) => ({
+      redirectTo301: value,
+    }),
+  },
+  redirect_to_302: {
+    transform: (value: any) => ({
+      redirectTo302: value,
+    }),
+  },
+};

--- a/packages/config/src/processConfig/strategy/implementations/buildProcessConfigStrategy.ts
+++ b/packages/config/src/processConfig/strategy/implementations/buildProcessConfigStrategy.ts
@@ -7,13 +7,20 @@ import ProcessConfigStrategy from '../processConfigStrategy';
  * @description This class is implementation of the Build Process Config Strategy.
  */
 class BuildProcessConfigStrategy extends ProcessConfigStrategy {
-  generate(config: AzionConfig) {
+  transformToManifest(config: AzionConfig) {
     const build = config?.build;
     if (!build) {
       return {};
     }
     const payload: AzionBuild = build;
     return payload;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformToConfig(payload: any, transformedPayload: AzionConfig) {
+    const build = payload?.build;
+    transformedPayload.build = build;
+    return transformedPayload.build;
   }
 }
 

--- a/packages/config/src/processConfig/strategy/implementations/domainProcessConfigStrategy.ts
+++ b/packages/config/src/processConfig/strategy/implementations/domainProcessConfigStrategy.ts
@@ -7,7 +7,7 @@ import ProcessConfigStrategy from '../processConfigStrategy';
  * @description This class is implementation of the Domain ProcessConfig Strategy.
  */
 class DomainProcessConfigStrategy extends ProcessConfigStrategy {
-  generate(config: AzionConfig) {
+  transformToManifest(config: AzionConfig) {
     const domain = config?.domain;
     if (!domain) {
       return {};
@@ -51,6 +51,25 @@ class DomainProcessConfigStrategy extends ProcessConfigStrategy {
       domainSetting.is_mtls_enabled = false;
     }
     return domainSetting;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformToConfig(payload: any, transformedPayload: AzionConfig) {
+    const domain = payload.domain || {};
+    transformedPayload.domain = {
+      name: domain.name,
+      cnameAccessOnly: domain.cname_access_only,
+      cnames: domain.cnames,
+      digitalCertificateId: domain.digital_certificate_id,
+      edgeApplicationId: domain.edge_application_id,
+      edgeFirewallId: domain.edge_firewall_id,
+      mtls: {
+        verification: domain.mtls_verification,
+        trustedCaCertificateId: domain.mtls_trusted_ca_certificate_id,
+        crlList: domain.crl_list,
+      },
+    };
+    return transformedPayload.domain;
   }
 }
 

--- a/packages/config/src/processConfig/strategy/implementations/purgeProcessConfigStrategy.ts
+++ b/packages/config/src/processConfig/strategy/implementations/purgeProcessConfigStrategy.ts
@@ -1,4 +1,4 @@
-import { AzionConfig } from '../../../types';
+import { AzionConfig, AzionPurge } from '../../../types';
 import ProcessConfigStrategy from '../processConfigStrategy';
 
 /**
@@ -7,7 +7,7 @@ import ProcessConfigStrategy from '../processConfigStrategy';
  * @description This class is implementation of the Purge ProcessConfig Strategy.
  */
 class PurgeProcessConfigStrategy extends ProcessConfigStrategy {
-  generate(config: AzionConfig) {
+  transformToManifest(config: AzionConfig) {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     const payload: any[] = [];
     if (!Array.isArray(config?.purge) || config?.purge.length === 0) {
@@ -38,6 +38,38 @@ class PurgeProcessConfigStrategy extends ProcessConfigStrategy {
       payload.push(purgeSetting);
     });
     return payload;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformToConfig(payload: any, transformedPayload: AzionConfig) {
+    const purgeConfig = payload.purge;
+    if (!Array.isArray(purgeConfig) || purgeConfig.length === 0) {
+      return;
+    }
+    transformedPayload.purge = [];
+    purgeConfig.forEach((purge) => {
+      purge.urls.forEach((value: string) => {
+        if (!value.includes('http://') && !value.includes('https://')) {
+          throw new Error('The URL must contain the protocol (http:// or https://).');
+        }
+
+        if (purge?.type === 'wildcard' && !value.includes('*')) {
+          throw new Error('The URL must not contain the wildcard character (*).');
+        }
+      });
+      const purgeSetting: AzionPurge = {
+        type: purge.type,
+        urls: purge.urls || [],
+        method: purge.method || 'delete',
+      };
+
+      if (purge?.type === 'cachekey') {
+        purgeSetting.layer = purge.layer || 'edge_caching';
+      }
+
+      transformedPayload.purge!.push(purgeSetting);
+    });
+    return transformedPayload.purge;
   }
 }
 

--- a/packages/config/src/processConfig/strategy/processConfigContext.ts
+++ b/packages/config/src/processConfig/strategy/processConfigContext.ts
@@ -15,12 +15,35 @@ class ProcessConfigContext {
   setStrategy(type: string, strategy: ProcessConfigStrategy): void {
     this.strategies[type] = strategy;
   }
+  /**
+   * Transform to manifest is responsible for transforming the config to the manifest.
+   * @param config AzionConfig
+   * @param context manifest object
+   * @returns
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  generate(config: AzionConfig, context: any) {
+  transformToManifest(config: AzionConfig, context: any) {
     Object.keys(this.strategies).forEach((key) => {
-      context[key] = this.strategies[key].generate(config, context);
+      context[key] = this.strategies[key].transformToManifest(config, context);
     });
     return context;
+  }
+
+  /**
+   * Transform to config is responsible for transforming the payload to the config.
+   * @param payload Manifest object
+   * @param transformedPayload AzionConfig object
+   * @returns
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformToConfig(payload: any, transformedPayload: AzionConfig): AzionConfig {
+    Object.keys(this.strategies).forEach((key) => {
+      transformedPayload[key as keyof AzionConfig] = this.strategies[key].transformToConfig(
+        payload,
+        transformedPayload,
+      );
+    });
+    return transformedPayload;
   }
 }
 

--- a/packages/config/src/processConfig/strategy/processConfigStrategy.ts
+++ b/packages/config/src/processConfig/strategy/processConfigStrategy.ts
@@ -8,8 +8,13 @@ import { AzionConfig } from '../../types';
 
 class ProcessConfigStrategy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  generate(config: AzionConfig, context: any) {
+  transformToManifest(config: AzionConfig, context: any) {
     return context;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+  transformToConfig(payload: any, transformedPayload: AzionConfig): AzionConfig | any {
+    return payload;
   }
 }
 


### PR DESCRIPTION
### Feat convert json config to config object

This function allows for converting a JSON configuration object to an `AzionConfig` object.

Usage:

```js
import { convertJsonConfigToObject } from 'azion';

const config = `{
  "origin": [
    {
      "name": 'my single origin',
      "origin_type": 'single_origin',
      "addresses": [
        {
          "address": 'http.bin.org',
        },
      ],
      "origin_path": '',
      "method": 'ip_hash',
      "origin_protocol_policy": 'preserve',
      "host_header": '${host}',
      "is_origin_redirection_enabled": true,
      "connection_timeout": 60,
      "timeout_between_bytes": 120,
      "hmac_authentication": true,
      "hmac_region_name": 'us-east-1',
      "hmac_access_key": 'myaccesskey',
      "hmac_secret_key": 'secretKey',
    },
  ],
}`;
const configObject = convertJsonConfigToObject(config);

```

Expect:

```js
configObject = {
      name: 'my single origin',
      type: 'single_origin',
      path: '',
      addresses: [
        {
          address: 'http.bin.org',
        },
      ],
      protocolPolicy: 'preserve',
      hostHeader: '${host}',
      method: 'ip_hash',
      redirection: true,
      connectionTimeout: 60,
      timeoutBetweenBytes: 120,
      hmac: {
        region: 'us-east-1',
        accessKey: 'myaccesskey',
        secretKey: 'secretKey',
      },
}
```