### PR TITLE
fix: resolve mathjs runtime configuration conflict

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,12 +1,18 @@
-import createAzionAIClient, { AzionAIClient } from 'azion/ai';
-import createAzionApplicationClient, { AzionApplicationsClient } from 'azion/applications';
+import type { AzionAIClient } from 'azion/ai';
+import createAzionAIClient from 'azion/ai';
+import type { AzionApplicationsClient } from 'azion/applications';
+import createAzionApplicationClient from 'azion/applications';
 import { convertJsonConfigToObject, defineConfig, processConfig } from 'azion/config';
-import createDomainsClient, { AzionDomainsClient } from 'azion/domains';
-import createPurgeClient, { AzionPurgeClient } from 'azion/purge';
-import createSqlClient, { AzionSQLClient } from 'azion/sql';
-import createStorageClient, { AzionStorageClient } from 'azion/storage';
+import type { AzionDomainsClient } from 'azion/domains';
+import createDomainsClient from 'azion/domains';
+import type { AzionPurgeClient } from 'azion/purge';
+import createPurgeClient from 'azion/purge';
+import type { AzionSQLClient } from 'azion/sql';
+import createSqlClient from 'azion/sql';
+import type { AzionStorageClient } from 'azion/storage';
+import createStorageClient from 'azion/storage';
 
-import { AzionClient, AzionClientConfig } from './types';
+import type { AzionClient, AzionClientConfig } from './types';
 
 /**
  * Creates an Azion Client with methods to interact with Azion services

--- a/packages/config/src/processConfig/strategy/implementations/cacheProcessConfigStrategy.ts
+++ b/packages/config/src/processConfig/strategy/implementations/cacheProcessConfigStrategy.ts
@@ -1,6 +1,8 @@
-import { evaluate } from 'mathjs';
+import { all, create } from 'mathjs';
 import { AzionCache, AzionConfig } from '../../../types';
 import ProcessConfigStrategy from '../processConfigStrategy';
+
+const math = create(all);
 
 /**
  * CacheProcessConfigStrategy
@@ -15,7 +17,7 @@ class CacheProcessConfigStrategy extends ProcessConfigStrategy {
       return expression;
     }
     if (/^[0-9+\-*/.() ]+$/.test(expression)) {
-      return evaluate(expression);
+      return math.evaluate(expression);
     }
     throw new Error(`Expression is not purely mathematical: ${expression}`);
   };


### PR DESCRIPTION
### Error using imports from the root package `azion` in edge-runtime:

`TypeError: The argument to 'typed' at index 1 is not a function (typed), nor an object with signatures as keys and functions as values.
data: {
index: 1,
argument: {
number: [Function],
'Complex | BigNumber | Fraction | Unit': [Function: Complex | BigNumber | Fraction | Unit],
bigint: [Function: bigint],
'Matrix | Matrix': [Object] }`

### Solution:
1 - Create an isolated instance of mathjs that has its own scope and does not interfere with the global environment, keeping its configurations encapsulated.