### PR TITLE
feat: add network list types and implement processing strategy

### DIFF
--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -85,3 +85,5 @@ export type FirewallRateLimitType = (typeof FIREWALL_RATE_LIMIT_TYPES)[number];
 export type FirewallRateLimitBy = (typeof FIREWALL_RATE_LIMIT_BY)[number];
 export type FirewallWafMode = (typeof FIREWALL_WAF_MODES)[number];
 export type FirewallVariable = (typeof FIREWALL_VARIABLES)[number];
+
+export const NETWORK_LIST_TYPES = ['ip_cidr', 'asn', 'countries'] as const;

--- a/packages/config/src/processConfig/helpers/schema.ts
+++ b/packages/config/src/processConfig/helpers/schema.ts
@@ -3,6 +3,7 @@ import {
   FIREWALL_RATE_LIMIT_TYPES,
   FIREWALL_VARIABLES,
   FIREWALL_WAF_MODES,
+  NETWORK_LIST_TYPES,
   RULE_CONDITIONALS,
   RULE_OPERATORS_WITH_VALUE,
   RULE_OPERATORS_WITHOUT_VALUE,
@@ -589,7 +590,7 @@ const azionConfigSchema = {
           },
           listType: {
             type: 'string',
-            enum: ['ip_cidr', 'asn', 'countries'],
+            enum: NETWORK_LIST_TYPES,
             errorMessage: "The 'listType' field must be a string. Accepted values are 'ip_cidr', 'asn' or 'countries'.",
           },
           listContent: {

--- a/packages/config/src/processConfig/helpers/schemaManifest.ts
+++ b/packages/config/src/processConfig/helpers/schemaManifest.ts
@@ -1,3 +1,5 @@
+import { NETWORK_LIST_TYPES } from '../../constants';
+
 const schemaNetworkListManifest = {
   type: 'object',
   properties: {
@@ -7,7 +9,7 @@ const schemaNetworkListManifest = {
     },
     list_type: {
       type: 'string',
-      enum: ['ip_cidr', 'asn', 'countries'],
+      enum: NETWORK_LIST_TYPES,
       errorMessage: "The 'list_type' field must be a string. Accepted values are 'ip_cidr', 'asn' or 'countries'.",
     },
     items_values: {

--- a/packages/config/src/processConfig/index.test.ts
+++ b/packages/config/src/processConfig/index.test.ts
@@ -2272,6 +2272,79 @@ describe('generate', () => {
         );
       });
     });
+    describe('Network List', () => {
+      it('should correctly process the config config when the network list is provided', () => {
+        const azionConfig: AzionConfig = {
+          networkList: [
+            {
+              id: 1,
+              listType: 'ip_cidr',
+              listContent: ['10.0.0.1'],
+            },
+            {
+              id: 2,
+              listType: 'asn',
+              listContent: [4569],
+            },
+            {
+              id: 3,
+              listType: 'countries',
+              listContent: ['BR'],
+            },
+          ],
+        };
+
+        const result = processConfig(azionConfig);
+        expect(result.networkList).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 1,
+              list_type: 'ip_cidr',
+              items_values: ['10.0.0.1'],
+            }),
+          ]),
+        );
+      });
+      it('should throw an error when the network list id is not a number', () => {
+        const azionConfig: any = {
+          networkList: [
+            {
+              id: '1',
+              listType: 'ip_cidr',
+              listContent: ['10.0.0.1'],
+            },
+          ],
+        };
+        expect(() => processConfig(azionConfig)).toThrow("The 'id' field must be a number.");
+      });
+      it('should throw an error when the network list listType is invalid', () => {
+        const azionConfig: any = {
+          networkList: [
+            {
+              id: 1,
+              listType: 'invalid',
+              listContent: ['10.0.0.1'],
+            },
+          ],
+        };
+        expect(() => processConfig(azionConfig)).toThrow(
+          "The 'listType' field must be a string. Accepted values are 'ip_cidr', 'asn' or 'countries'.",
+        );
+      });
+      it('should throw an error when the network list required fields are not provided', () => {
+        const azionConfig: any = {
+          networkList: [
+            {
+              id: 1,
+              listType: 'ip_cidr',
+            },
+          ],
+        };
+        expect(() => processConfig(azionConfig)).toThrow(
+          "The 'id, listType and listContent' fields are required in each network list item.",
+        );
+      });
+    });
   });
 
   describe('convertJsonConfigToObject', () => {
@@ -3679,6 +3752,82 @@ describe('generate', () => {
             ]),
           );
         });
+      });
+    });
+    describe('Network List', () => {
+      it('should correctly process the config network list', () => {
+        const jsonConfig = {
+          networkList: [
+            {
+              id: 1,
+              list_type: 'ip_cidr',
+              items_values: ['10.0.0.1'],
+            },
+            {
+              id: 2,
+              list_type: 'asn',
+              items_values: ['AS123'],
+            },
+            {
+              id: 3,
+              list_type: 'countries',
+              items_values: ['US'],
+            },
+          ],
+        };
+
+        const result = convertJsonConfigToObject(JSON.stringify(jsonConfig));
+        expect(result.networkList).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 1,
+              listType: 'ip_cidr',
+              listContent: ['10.0.0.1'],
+            }),
+          ]),
+        );
+      });
+      it('should throw an error when the network list id is not a number', () => {
+        const jsonConfig = {
+          networkList: [
+            {
+              id: '1',
+              list_type: 'ip_cidr',
+              items_values: ['10.0.0.1'],
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow("The 'id' field must be a number.");
+      });
+      it('should throw an error when the network list list_type is not valid', () => {
+        const jsonConfig = {
+          networkList: [
+            {
+              id: 1,
+              list_type: 'invalid',
+              items_values: ['10.0.0.1'],
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+          "The 'list_type' field must be a string. Accepted values are 'ip_cidr', 'asn' or 'countries'.",
+        );
+      });
+      it('should throw an error when the network list required fields are not provided', () => {
+        const jsonConfig = {
+          networkList: [
+            {
+              id: 1,
+              list_type: 'ip_cidr',
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+          "The 'id, list_type and items_values' fields are required in each network list item.",
+        );
       });
     });
   });

--- a/packages/config/src/processConfig/strategy/implementations/secure/networkListProcessConfigStrategy.ts
+++ b/packages/config/src/processConfig/strategy/implementations/secure/networkListProcessConfigStrategy.ts
@@ -1,0 +1,48 @@
+import { AzionConfig } from '../../../../types';
+import ProcessConfigStrategy from '../../processConfigStrategy';
+
+/**
+ * NetworkListProcessConfigStrategy
+ * @class NetworkListProcessConfigStrategy
+ * @description This class is implementation of the NetworkList Process Config Strategy.
+ */
+class NetworkListProcessConfigStrategy extends ProcessConfigStrategy {
+  transformToManifest(config: AzionConfig) {
+    const networkList = config?.networkList;
+    if (!Array.isArray(networkList) || networkList.length === 0) {
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const payload: any[] = [];
+    networkList.forEach((network) => {
+      const item = {
+        id: network.id,
+        list_type: network.listType,
+        items_values: network.listContent,
+      };
+      payload.push(item);
+    });
+
+    return payload;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformToConfig(payload: any, transformedPayload: AzionConfig) {
+    const networkList = payload?.networkList;
+    if (!Array.isArray(networkList) || networkList.length === 0) {
+      return;
+    }
+    transformedPayload.networkList = [];
+    networkList.forEach((network) => {
+      const item = {
+        id: network.id,
+        listType: network.list_type,
+        listContent: network.items_values,
+      };
+      transformedPayload.networkList!.push(item);
+    });
+    return transformedPayload.networkList;
+  }
+}
+
+export default NetworkListProcessConfigStrategy;


### PR DESCRIPTION
This pull request introduces a new feature to handle network lists in the configuration processing system. The changes include adding constants, modifying schemas, updating validation logic, and adding new tests to ensure the correct processing of network lists.

### Network List Feature:

* [`packages/config/src/constants.ts`](diffhunk://#diff-211627e272d8e1db6e01d86ea127b286632a3fb2bccbbe4e29844d4b72ef9c38R88-R89): Added `NETWORK_LIST_TYPES` constant to define the accepted values for network lists.
* [`packages/config/src/processConfig/helpers/schema.ts`](diffhunk://#diff-d7f5cddc4e51d20a98665915e59cb0d9b527b0e01e56d2dc02496173edf7602cR6): Updated the schema to use `NETWORK_LIST_TYPES` for the `listType` field. [[1]](diffhunk://#diff-d7f5cddc4e51d20a98665915e59cb0d9b527b0e01e56d2dc02496173edf7602cR6) [[2]](diffhunk://#diff-d7f5cddc4e51d20a98665915e59cb0d9b527b0e01e56d2dc02496173edf7602cL592-R593)
* [`packages/config/src/processConfig/helpers/schemaManifest.ts`](diffhunk://#diff-1d899ca38032e22c354aaf138586daca5b66b3c8c08bac1970754059b1b227bbR1-R2): Added import for `NETWORK_LIST_TYPES` and updated the schema to use it for the `list_type` field. [[1]](diffhunk://#diff-1d899ca38032e22c354aaf138586daca5b66b3c8c08bac1970754059b1b227bbR1-R2) [[2]](diffhunk://#diff-1d899ca38032e22c354aaf138586daca5b66b3c8c08bac1970754059b1b227bbL10-R12)
* [`packages/config/src/processConfig/index.ts`](diffhunk://#diff-9aab7baca173cdc0bf2792428e078e8cd5b8c0596c024034bba73b8b775cacc5R8-R33): Updated the `validateConfig` function to accept a schema parameter and added `NetworkListProcessConfigStrategy` to the process context. [[1]](diffhunk://#diff-9aab7baca173cdc0bf2792428e078e8cd5b8c0596c024034bba73b8b775cacc5R8-R33) [[2]](diffhunk://#diff-9aab7baca173cdc0bf2792428e078e8cd5b8c0596c024034bba73b8b775cacc5R52) [[3]](diffhunk://#diff-9aab7baca173cdc0bf2792428e078e8cd5b8c0596c024034bba73b8b775cacc5L124-R131)
* [`packages/config/src/processConfig/strategy/implementations/secure/networkListProcessConfigStrategy.ts`](diffhunk://#diff-8539483cd15fb5e3598cdd9c0dba0dcbb5023e5afceb757fcc92dc485d2371baR1-R48): Added a new strategy class `NetworkListProcessConfigStrategy` to handle the transformation of network lists between config and manifest formats.

### Tests:

* [`packages/config/src/processConfig/index.test.ts`](diffhunk://#diff-60bb808f2e2b365e23323f2b5324075e84bc2f8227a14408fccadc0679967948R2275-R2347): Added tests to verify the correct processing of network lists, including validation of required fields and accepted values. [[1]](diffhunk://#diff-60bb808f2e2b365e23323f2b5324075e84bc2f8227a14408fccadc0679967948R2275-R2347) [[2]](diffhunk://#diff-60bb808f2e2b365e23323f2b5324075e84bc2f8227a14408fccadc0679967948R3757-R3832)