### PR TITLE
feat: add WAF configuration type and properties to AzionConfig

### DIFF
--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -7,6 +7,8 @@ import {
   RuleOperatorWithValue,
   RuleOperatorWithoutValue,
   RuleVariable,
+  WafMode,
+  WafSensitivity,
 } from './constants';
 
 /**
@@ -358,6 +360,8 @@ export type AzionConfig = {
   firewall?: AzionFirewall;
   /** Network list configurations */
   networkList?: AzionNetworkList[];
+  /** WAF configuration */
+  waf?: AzionWaf[];
 };
 
 /**
@@ -465,4 +469,47 @@ export type AzionFirewall = {
   rules?: AzionFirewallRule[];
   /** Debug mode */
   debugRules?: boolean;
+};
+
+export type AzionWaf = {
+  /** WAF name */
+  name: string;
+  /** WAF mode */
+  mode: WafMode;
+  /** WAF active */
+  active: boolean;
+  /** WAF sqlInjection */
+  sqlInjection?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF remoteFileInclusion */
+  remoteFileInclusion?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF directoryTraversal */
+  directoryTraversal?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF crossSiteScripting */
+  crossSiteScripting?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF evadingTricks */
+  evadingTricks?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF fileUpload */
+  fileUpload?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF unwantedAccess */
+  unwantedAccess?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF identityAttack */
+  identityAttack?: {
+    sensitivity: WafSensitivity;
+  };
+  /** WAF bypassAddress */
+  bypassAddress?: string[];
 };


### PR DESCRIPTION
This pull request introduces new configurations for the Web Application Firewall (WAF) in the `packages/config/src/types.ts` file. The changes include adding new types and properties to support the WAF configuration.

### New WAF Configuration:

* Added `WafMode` and `WafSensitivity` to the import statements.
* Introduced a new `waf` property in the `AzionConfig` type to hold WAF configurations.
* Defined a new `AzionWaf` type with various properties for configuring different WAF rules and their sensitivities.