### PR TITLE
feat:  firewall, domains and applications manifest schema

### DIFF
--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -143,3 +143,26 @@ export const WAF_MODE = ['learning', 'blocking', 'counting'] as const;
 export type WafMode = (typeof WAF_MODE)[number];
 export const WAF_SENSITIVITY = ['low', 'medium', 'high'] as const;
 export type WafSensitivity = (typeof WAF_SENSITIVITY)[number];
+
+export const FIREWALL_RULE_OPERATORS = [
+  'is_equal',
+  'is_not_equal',
+  'starts_with',
+  'does_not_start_with',
+  'matches',
+  'does_not_match',
+  'exists',
+  'does_not_exist',
+  'is_in_list',
+  'is_not_in_list',
+] as const;
+
+export const FIREWALL_RULE_CONDITIONALS = ['if', 'and', 'or'] as const;
+
+export const FIREWALL_RATE_LIMIT_ARGUMENTS = {
+  type: ['second', 'minute'],
+  limit_by: ['client_ip', 'global'],
+} as const;
+
+export type FirewallRuleOperator = (typeof FIREWALL_RULE_OPERATORS)[number];
+export type FirewallRuleConditional = (typeof FIREWALL_RULE_CONDITIONALS)[number];

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -166,3 +166,82 @@ export const FIREWALL_RATE_LIMIT_ARGUMENTS = {
 
 export type FirewallRuleOperator = (typeof FIREWALL_RULE_OPERATORS)[number];
 export type FirewallRuleConditional = (typeof FIREWALL_RULE_CONDITIONALS)[number];
+
+// Novas constantes para Application
+export const APPLICATION_DELIVERY_PROTOCOLS = ['http,https', 'http'] as const;
+export const APPLICATION_TLS_VERSIONS = ['', 'tls_1_0', 'tls_1_1', 'tls_1_2', 'tls_1_3'] as const;
+export const APPLICATION_SUPPORTED_CIPHERS = [
+  'all',
+  'TLSv1.2_2018',
+  'TLSv1.2_2019',
+  'TLSv1.2_2021',
+  'TLSv1.3_2022',
+] as const;
+export const APPLICATION_HTTP_PORTS = [80, 8008, 8080] as const;
+export const APPLICATION_HTTPS_PORTS = [443, 8443, 9440, 9441, 9442, 9443] as const;
+
+// Tipos para as novas constantes
+export type ApplicationDeliveryProtocol = (typeof APPLICATION_DELIVERY_PROTOCOLS)[number];
+export type ApplicationTlsVersion = (typeof APPLICATION_TLS_VERSIONS)[number];
+export type ApplicationSupportedCipher = (typeof APPLICATION_SUPPORTED_CIPHERS)[number];
+export type ApplicationHttpPort = (typeof APPLICATION_HTTP_PORTS)[number];
+export type ApplicationHttpsPort = (typeof APPLICATION_HTTPS_PORTS)[number];
+
+// Novas constantes para Cache Settings
+export const CACHE_BROWSER_SETTINGS = ['honor', 'override'] as const;
+export const CACHE_CDN_SETTINGS = ['honor', 'override'] as const;
+export const CACHE_BY_QUERY_STRING = ['ignore', 'whitelist', 'blacklist', 'all'] as const;
+export const CACHE_BY_COOKIE = ['ignore', 'whitelist', 'blacklist', 'all'] as const;
+export const CACHE_ADAPTIVE_DELIVERY = ['ignore', 'whitelist'] as const;
+export const CACHE_L2_REGION = [null, 'sa-brazil', 'na-united-states'] as const;
+
+// Tipos para as novas constantes
+export type CacheBrowserSetting = (typeof CACHE_BROWSER_SETTINGS)[number];
+export type CacheCdnSetting = (typeof CACHE_CDN_SETTINGS)[number];
+export type CacheByQueryString = (typeof CACHE_BY_QUERY_STRING)[number];
+export type CacheByCookie = (typeof CACHE_BY_COOKIE)[number];
+export type CacheAdaptiveDelivery = (typeof CACHE_ADAPTIVE_DELIVERY)[number];
+export type CacheL2Region = (typeof CACHE_L2_REGION)[number];
+
+// Constantes para Origins
+export const ORIGIN_TYPES = ['single_origin', 'load_balancer', 'live_ingest', 'object_storage'] as const;
+export const ORIGIN_PROTOCOL_POLICIES = ['preserve', 'http', 'https'] as const;
+export const LOAD_BALANCER_METHODS = ['ip_hash', 'least_connections', 'round_robin'] as const;
+
+// Tipos para Origins
+export type OriginType = (typeof ORIGIN_TYPES)[number];
+export type OriginProtocolPolicy = (typeof ORIGIN_PROTOCOL_POLICIES)[number];
+export type LoadBalancerMethod = (typeof LOAD_BALANCER_METHODS)[number];
+
+// Constantes para Rules
+export const RULE_PHASES = ['request', 'response'] as const;
+
+export const RULE_BEHAVIOR_NAMES = [
+  'add_request_cookie',
+  'add_request_header',
+  'add_response_header',
+  'bypass_cache_phase',
+  'capture_match_groups',
+  'deliver',
+  'deny',
+  'enable_gzip',
+  'filter_request_cookie',
+  'filter_response_cookie',
+  'filter_request_header',
+  'filter_response_header',
+  'forward_cookies',
+  'no_content',
+  'optimize_images',
+  'redirect_http_to_https',
+  'redirect_to_301',
+  'redirect_to_302',
+  'rewrite_request',
+  'run_function',
+  'set_cache_policy',
+  'set_cookie',
+  'set_origin',
+] as const;
+
+// Tipos para Rules
+export type RulePhase = (typeof RULE_PHASES)[number];
+export type RuleBehaviorName = (typeof RULE_BEHAVIOR_NAMES)[number];

--- a/packages/config/src/processConfig/helpers/schemaManifest.ts
+++ b/packages/config/src/processConfig/helpers/schemaManifest.ts
@@ -431,32 +431,43 @@ const schemaFirewallRule = {
 const schemaFirewallManifest = {
   type: 'object',
   properties: {
-    name: {
-      type: 'string',
-      errorMessage: "The 'name' field must be a string.",
-    },
-    domains: {
-      type: 'array',
-      items: {
-        type: 'number',
+    main_settings: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          errorMessage: "The 'name' field must be a string.",
+        },
+        domains: {
+          type: 'array',
+          items: {
+            type: 'number',
+          },
+          errorMessage: "The 'domains' field must be an array of numbers.",
+        },
+        is_active: {
+          type: 'boolean',
+          errorMessage: "The 'is_active' field must be a boolean.",
+        },
+        edge_functions_enabled: {
+          type: 'boolean',
+          errorMessage: "The 'edge_functions_enabled' field must be a boolean.",
+        },
+        network_protection_enabled: {
+          type: 'boolean',
+          errorMessage: "The 'network_protection_enabled' field must be a boolean.",
+        },
+        waf_enabled: {
+          type: 'boolean',
+          errorMessage: "The 'waf_enabled' field must be a boolean.",
+        },
       },
-      errorMessage: "The 'domains' field must be an array of numbers.",
-    },
-    is_active: {
-      type: 'boolean',
-      errorMessage: "The 'is_active' field must be a boolean.",
-    },
-    edge_functions_enabled: {
-      type: 'boolean',
-      errorMessage: "The 'edge_functions_enabled' field must be a boolean.",
-    },
-    network_protection_enabled: {
-      type: 'boolean',
-      errorMessage: "The 'network_protection_enabled' field must be a boolean.",
-    },
-    waf_enabled: {
-      type: 'boolean',
-      errorMessage: "The 'waf_enabled' field must be a boolean.",
+      required: ['name'],
+      additionalProperties: false,
+      errorMessage: {
+        additionalProperties: 'No additional properties are allowed in firewall main settings.',
+        required: "The 'name' field is required in firewall main settings.",
+      },
     },
     rules: {
       type: 'array',
@@ -464,11 +475,11 @@ const schemaFirewallManifest = {
       errorMessage: "The 'rules' field must be an array of firewall rules.",
     },
   },
-  required: ['name'],
+  required: ['main_settings'],
   additionalProperties: false,
   errorMessage: {
     additionalProperties: 'No additional properties are allowed in firewall items.',
-    required: "The 'name' field is required in each firewall item.",
+    required: "The 'main_settings' field is required in each firewall item.",
   },
 };
 

--- a/packages/config/src/processConfig/helpers/schemaManifest.ts
+++ b/packages/config/src/processConfig/helpers/schemaManifest.ts
@@ -159,6 +159,99 @@ const schemaWafManifest = {
   },
 };
 
+const schemaDomainsManifest = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'number',
+      errorMessage: "The 'id' field must be a number.",
+    },
+    name: {
+      type: 'string',
+      errorMessage: "The 'name' field must be a string.",
+    },
+    edge_application_id: {
+      type: 'number',
+      errorMessage: "The 'edge_application_id' field must be a number.",
+    },
+    cnames: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      errorMessage: "The 'cnames' field must be an array of strings.",
+    },
+    cname_access_only: {
+      type: 'boolean',
+      errorMessage: "The 'cname_access_only' field must be a boolean.",
+    },
+    digital_certificate_id: {
+      oneOf: [{ type: 'number' }, { type: 'string', enum: ['lets_encrypt'] }, { type: 'null' }],
+      errorMessage: "The 'digital_certificate_id' field must be a number, 'lets_encrypt' or null.",
+    },
+    is_active: {
+      type: 'boolean',
+      default: true,
+      errorMessage: "The 'is_active' field must be a boolean.",
+    },
+    domain_name: {
+      type: 'string',
+      errorMessage: "The 'domain_name' field must be a string.",
+    },
+    is_mtls_enabled: {
+      type: 'boolean',
+      errorMessage: "The 'is_mtls_enabled' field must be a boolean.",
+    },
+    mtls_verification: {
+      type: 'string',
+      enum: ['enforce', 'permissive'],
+      errorMessage: "The 'mtls_verification' field must be either 'enforce' or 'permissive'.",
+    },
+    mtls_trusted_ca_certificate_id: {
+      type: 'number',
+      errorMessage: "The 'mtls_trusted_ca_certificate_id' field must be a number.",
+    },
+    edge_firewall_id: {
+      type: 'number',
+      errorMessage: "The 'edge_firewall_id' field must be a number.",
+    },
+    crl_list: {
+      type: 'array',
+      items: {
+        type: 'number',
+      },
+      errorMessage: "The 'crl_list' field must be an array of numbers.",
+    },
+  },
+  required: ['name', 'edge_application_id', 'cnames', 'cname_access_only', 'digital_certificate_id'],
+  dependencies: {
+    is_mtls_enabled: {
+      oneOf: [
+        {
+          properties: {
+            is_mtls_enabled: { enum: [false] },
+          },
+        },
+        {
+          properties: {
+            is_mtls_enabled: { enum: [true] },
+          },
+          required: ['mtls_verification', 'mtls_trusted_ca_certificate_id'],
+        },
+      ],
+    },
+  },
+  additionalProperties: false,
+  errorMessage: {
+    additionalProperties: 'No additional properties are allowed in domain items.',
+    required:
+      "The 'name', 'edge_application_id', 'cnames', 'cname_access_only', and 'digital_certificate_id' fields are required.",
+    dependencies: {
+      is_mtls_enabled: "When mTLS is enabled, 'mtls_verification' and 'mtls_trusted_ca_certificate_id' are required.",
+    },
+  },
+};
+
 const schemaManifest = {
   type: 'object',
   properties: {
@@ -173,6 +266,11 @@ const schemaManifest = {
       errorMessage: {
         type: "The 'waf' field must be an array",
       },
+    },
+    domains: {
+      type: 'array',
+      items: schemaDomainsManifest,
+      errorMessage: "The 'domains' field must be an array of domain items.",
     },
   },
 };

--- a/packages/config/src/processConfig/index.test.ts
+++ b/packages/config/src/processConfig/index.test.ts
@@ -4175,9 +4175,6 @@ describe('generate', () => {
         );
       });
     });
-  });
-
-  describe('Schema Validation', () => {
     describe('Domains', () => {
       it('should throw error when required fields are missing', () => {
         const jsonConfig = {
@@ -4218,6 +4215,101 @@ describe('generate', () => {
               cname_access_only: false,
               digital_certificate_id: 'lets_encrypt',
               crl_list: ['invalid', 'values'],
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+    });
+    describe('Firewall', () => {
+      it('should throw error when required fields are missing', () => {
+        const jsonConfig = {
+          firewall: [
+            {
+              // missing name field
+              is_active: true,
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+
+      it('should throw error when rule criteria is invalid', () => {
+        const jsonConfig = {
+          firewall: [
+            {
+              name: 'my-firewall',
+              rules: [
+                {
+                  name: 'invalid-rule',
+                  criteria: {
+                    variable: 'invalid_variable',
+                    operator: 'is_equal',
+                    conditional: 'if',
+                    input_value: 'test',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+
+      it('should throw error when behavior name is invalid', () => {
+        const jsonConfig = {
+          firewall: [
+            {
+              name: 'my-firewall',
+              rules: [
+                {
+                  name: 'invalid-behavior',
+                  criteria: {
+                    variable: 'request_uri',
+                    operator: 'is_equal',
+                    conditional: 'if',
+                    input_value: '/test',
+                  },
+                  behavior: {
+                    name: 'invalid_behavior',
+                    target: 'test',
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+
+      it('should throw error when rate limit arguments are invalid', () => {
+        const jsonConfig = {
+          firewall: [
+            {
+              name: 'my-firewall',
+              rules: [
+                {
+                  name: 'invalid-rate-limit',
+                  criteria: {
+                    variable: 'request_uri',
+                    operator: 'is_equal',
+                    conditional: 'if',
+                    input_value: '/test',
+                  },
+                  behavior: {
+                    name: 'set_rate_limit',
+                    target: {
+                      type: 'invalid',
+                      limit_by: 'invalid',
+                      average_rate_limit: 'not_a_number',
+                    },
+                  },
+                },
+              ],
             },
           ],
         };

--- a/packages/config/src/processConfig/index.test.ts
+++ b/packages/config/src/processConfig/index.test.ts
@@ -4176,4 +4176,54 @@ describe('generate', () => {
       });
     });
   });
+
+  describe('Schema Validation', () => {
+    describe('Domains', () => {
+      it('should throw error when required fields are missing', () => {
+        const jsonConfig = {
+          domains: [
+            {
+              name: 'mydomain.com',
+              // missing required fields
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+
+      it('should throw error for invalid digital_certificate_id value', () => {
+        const jsonConfig = {
+          domains: [
+            {
+              name: 'mydomain.com',
+              edge_application_id: 123,
+              cnames: ['www.mydomain.com'],
+              cname_access_only: false,
+              digital_certificate_id: 'invalid_value',
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+
+      it('should throw error for invalid crl_list values', () => {
+        const jsonConfig = {
+          domains: [
+            {
+              name: 'mydomain.com',
+              edge_application_id: 123,
+              cnames: ['www.mydomain.com'],
+              cname_access_only: false,
+              digital_certificate_id: 'lets_encrypt',
+              crl_list: ['invalid', 'values'],
+            },
+          ],
+        };
+
+        expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
+      });
+    });
+  });
 });

--- a/packages/config/src/processConfig/index.test.ts
+++ b/packages/config/src/processConfig/index.test.ts
@@ -4317,5 +4317,248 @@ describe('generate', () => {
         expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow();
       });
     });
+    describe('Application', () => {
+      describe('Main Settings', () => {
+        it('should throw an error when delivery_protocol is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                  delivery_protocol: 'invalid',
+                },
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'delivery_protocol' field must be either 'http,https' or 'http'.",
+          );
+        });
+
+        it('should throw an error when http_port is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                  http_port: 'invalid',
+                },
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'http_port' field must be an array",
+          );
+        });
+      });
+
+      describe('Cache Settings', () => {
+        it('should throw an error when browser_cache_settings is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                cache_settings: [
+                  {
+                    name: 'test',
+                    browser_cache_settings: 'invalid',
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'browser_cache_settings' must be either 'honor' or 'override'.",
+          );
+        });
+
+        it('should throw an error when cache_by_query_string is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                cache_settings: [
+                  {
+                    name: 'test',
+                    cache_by_query_string: 'invalid',
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'cache_by_query_string' must be one of: ignore, whitelist, blacklist, all.",
+          );
+        });
+      });
+
+      describe('Origins', () => {
+        it('should throw an error when origin_type is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                origins: [
+                  {
+                    name: 'test',
+                    origin_type: 'invalid',
+                    addresses: [{ address: 'example.com' }],
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'origin_type' field must be one of: single_origin, load_balancer, live_ingest, object_storage.",
+          );
+        });
+
+        it('should throw an error when bucket is missing for object_storage type', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                origins: [
+                  {
+                    name: 'test',
+                    origin_type: 'object_storage',
+                    addresses: [{ address: 'example.com' }],
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "When origin_type is 'object_storage', the 'bucket' field is required.",
+          );
+        });
+      });
+
+      describe('Rules', () => {
+        it('should throw an error when criteria variable is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                rules: [
+                  {
+                    name: 'test',
+                    criteria: [
+                      [
+                        {
+                          variable: 'invalid_variable',
+                          operator: 'matches',
+                          conditional: 'if',
+                          input_value: '/test',
+                        },
+                      ],
+                    ],
+                    behaviors: [
+                      {
+                        name: 'deliver',
+                        target: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'variable' field must be a valid variable name.",
+          );
+        });
+
+        it('should throw an error when behavior name is invalid', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                rules: [
+                  {
+                    name: 'test',
+                    criteria: [
+                      [
+                        {
+                          variable: 'request_uri',
+                          operator: 'matches',
+                          conditional: 'if',
+                          input_value: '/test',
+                        },
+                      ],
+                    ],
+                    behaviors: [
+                      {
+                        name: 'invalid_behavior',
+                        target: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The 'name' field must be a valid behavior name.",
+          );
+        });
+
+        it('should throw an error when input_value is missing for operator that requires it', () => {
+          const jsonConfig = {
+            application: [
+              {
+                main_settings: {
+                  name: 'test',
+                },
+                rules: [
+                  {
+                    name: 'test',
+                    criteria: [
+                      [
+                        {
+                          variable: 'request_uri',
+                          operator: 'matches',
+                          conditional: 'if',
+                        },
+                      ],
+                    ],
+                    behaviors: [
+                      {
+                        name: 'deliver',
+                        target: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+
+          expect(() => convertJsonConfigToObject(JSON.stringify(jsonConfig))).toThrow(
+            "The operator 'matches' requires an input_value.",
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/config/src/processConfig/index.test.ts
+++ b/packages/config/src/processConfig/index.test.ts
@@ -4227,8 +4227,11 @@ describe('generate', () => {
         const jsonConfig = {
           firewall: [
             {
-              // missing name field
-              is_active: true,
+              main_settings: {
+                // missing name field
+                is_active: true,
+              },
+              rules: [],
             },
           ],
         };
@@ -4240,7 +4243,10 @@ describe('generate', () => {
         const jsonConfig = {
           firewall: [
             {
-              name: 'my-firewall',
+              main_settings: {
+                name: 'my-firewall',
+                is_active: true,
+              },
               rules: [
                 {
                   name: 'invalid-rule',
@@ -4263,7 +4269,10 @@ describe('generate', () => {
         const jsonConfig = {
           firewall: [
             {
-              name: 'my-firewall',
+              main_settings: {
+                name: 'my-firewall',
+                is_active: true,
+              },
               rules: [
                 {
                   name: 'invalid-behavior',
@@ -4290,7 +4299,10 @@ describe('generate', () => {
         const jsonConfig = {
           firewall: [
             {
-              name: 'my-firewall',
+              main_settings: {
+                name: 'my-firewall',
+                is_active: true,
+              },
               rules: [
                 {
                   name: 'invalid-rate-limit',


### PR DESCRIPTION
## Description
Created a new schema manifest to handle configuration validation for the `convertJsonConfigToObject` function. This schema is designed to validate the structure of configurations, ensuring data integrity and proper formatting.

### Changes Made
- Created `schemaManifest.ts` with comprehensive validation schemas for:
- Application schema
- Domains schema
- Firewall Schema

### Technical Details
- Added validation for required fields and proper data types
- Implemented enum validations for specific fields
- Added clear error messages for validation failures
- Maintained consistency with existing schema structure
- Ensured proper typing and TypeScript support

### Why
This change is necessary to:
1. Validate processed configurations before they are converted back to config objects
2. Ensure data integrity during the conversion process
3. Provide clear error messages when validation fails
4. Maintain consistency between input and output schemas
