### PR TITLE
docs: add WAF documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ const config = {
   cache: [],
   rules: [],
   purge: [],
+  networkList: [],
+  waf: [],
 };
 
 export default config;
@@ -218,6 +220,8 @@ const config = defineConfig({
   cache: [],
   rules: [],
   purge: [],
+  networkList: [],
+  waf: [],
 });
 
 export default config;

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -25,6 +25,7 @@ This module provides a function to configure and validate options for the Azion 
   - [`AzionPurge`](#azionpurge)
   - [`AzionNetworkList`](#azionnetworklist)
   - [`AzionFirewall`](#azionfirewall)
+  - [`AzionWaf`](#azionwaf)
 
 ## Installation
 
@@ -297,6 +298,7 @@ Converts a Azion JSON configuration object to a AzionConfig object.
 - `rules?: AzionRules[]` - List of edge rules.
 - `purge?: AzionPurge[]` - List of URLs or CacheKeys to purge.
 - `networkLists?: AzionNetworkList[]` - List of network lists.
+- `waf?: AzionWaf[]` - List of WAF configurations.
 
 ### `AzionBuild`
 
@@ -515,3 +517,31 @@ Type definition for the response rule configuration.
   - `conditional: RuleConditional` - Conditional type.
   - `operator: RuleOperatorWithValue | RuleOperatorWithoutValue` - Comparison operator.
   - `inputValue?: string` - Input value for comparison (required for operators with value).
+
+  ### `AzionWaf`
+
+  Type definition for the Web Application Firewall (WAF) configuration.
+
+  **Properties:**
+
+  - `id?: number` - ID of the WAF.
+  - `name: string` - Name of the WAF.
+  - `active: boolean` - Whether the WAF is active.
+  - `mode: WafMode` - WAF mode (learning, blocking and counting).
+  - `sqlInjection?: object` - SQL Injection settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `remoteFileInclusion?: object` - Remote File Inclusion settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `directoryTraversal?: object` - Directory Traversal settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `crossSiteScripting?: object` - Cross-Site Scripting settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `evadingTricks?: object` - Evading Tricks settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `fileUpload?: object` - File Upload settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `unwantedAccess?: object` - Unwanted Access settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `identifiedAttack?: object` - Identified Attack settings.
+    - `sensitivity: string` - Sensitivity level (low, medium, high).
+  - `bypassAdresses?: string[]` - List of IP addresses to bypass the WAF.


### PR DESCRIPTION
This pull request adds support for Web Application Firewall (WAF) configurations to the project. The changes include updates to the configuration object and documentation to integrate WAF settings.

### Configuration Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R204-R205): Added  `waf` properties to the configuration object. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R204-R205) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R223-R224)

### Documentation Updates:
* [`packages/config/README.md`](diffhunk://#diff-08bfd3800f046f2c979ef3bdc4c668abb136c724eb8de752af1ad2fd732840ccR28): Added `AzionWaf` to the list of configuration options and detailed the properties of the WAF configuration. [[1]](diffhunk://#diff-08bfd3800f046f2c979ef3bdc4c668abb136c724eb8de752af1ad2fd732840ccR28) [[2]](diffhunk://#diff-08bfd3800f046f2c979ef3bdc4c668abb136c724eb8de752af1ad2fd732840ccR301) [[3]](diffhunk://#diff-08bfd3800f046f2c979ef3bdc4c668abb136c724eb8de752af1ad2fd732840ccR520-R547)