### PR TITLE
fix: add crypto-browserify as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "chalk": "^5.3.0",
+        "crypto-browserify": "^3.12.1",
         "progress": "^2.0.3"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
+    "crypto-browserify": "^3.12.1",
     "progress": "^2.0.3"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds the `crypto-browserify` dependency to the project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R213): Added `crypto-browserify` dependency with version `^3.12.1`.