### PR TITLE
feat: add temporary polyfills for performance and navigator in unenv-preset

### DIFF
--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -14,6 +14,8 @@ export default {
     __dirname: `${polyfillsPath}/node/globals/path-dirname.js`,
     __filename: `${polyfillsPath}/node/globals/path-filename.js`,
     process: `${polyfillsPath}/node/globals/process.cjs`,
+    performance: `${polyfillsPath}/node/globals/performance.js`,
+    navigator: `${polyfillsPath}/node/globals/navigator.js`,
   },
   alias: {
     'azion/utils': 'azion/utils',

--- a/packages/unenv-preset/src/polyfills/node/globals/navigator.js
+++ b/packages/unenv-preset/src/polyfills/node/globals/navigator.js
@@ -1,0 +1,6 @@
+// This a temporary polyfill for navigator.
+globalThis.navigator = {
+  userAgent: 'edge-runtime/1.0 (polyfill)',
+};
+
+export default globalThis.navigator;

--- a/packages/unenv-preset/src/polyfills/node/globals/performance.js
+++ b/packages/unenv-preset/src/polyfills/node/globals/performance.js
@@ -1,0 +1,51 @@
+/**
+ * This a temporary polyfill for performance.now() in Node.js
+ * unenv v2 will have a better solution for this.
+ * https://www.npmjs.com/package/unenv/v/2.0.0-rc.1?activeTab=code
+ * 
+ * 
+ * Copyright (c) 2013 Braveg1rl
+ * github.com/braveg1rl/performance-now
+ 
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+  of the Software, and to permit persons to whom the Software is furnished to do
+  so, subject to the following conditions:
+ 
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+ 
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+let loadTime = Date.now();
+globalThis.performance = new Proxy(
+  {},
+  {
+    get(target, prop) {
+      if (prop === 'now') {
+        return () => {
+          const result = Date.now() - loadTime;
+          loadTime = Date.now();
+
+          return result;
+        };
+      }
+      return () => {
+        const result = Date.now() - loadTime;
+        loadTime = Date.now();
+
+        return result;
+      };
+    },
+  },
+);
+export default globalThis.performance;


### PR DESCRIPTION
This pull request adds temporary polyfills for `performance` and `navigator` in the `unenv-preset` package. These changes ensure compatibility with environments that do not natively support these global objects.

### Additions of polyfills:

* [`packages/unenv-preset/src/index.ts`](diffhunk://#diff-40a0c89863390a48518ad7870d9042ad049b987f88f48b67368e0b4f9570a450R17-R18): Added `performance` and `navigator` to the list of polyfills.
* [`packages/unenv-preset/src/polyfills/node/globals/navigator.js`](diffhunk://#diff-6b23060d8dbbbd734331cd081aacf728e59d0e556981b6fe2e2d4f9acf6f9292R1-R6): Introduced a temporary polyfill for `navigator` with a basic `userAgent` property.
* [`packages/unenv-preset/src/polyfills/node/globals/performance.js`](diffhunk://#diff-91bcc7dd4e74c11205ccdc264143a10035d658d4621fd5237b1fa1c1a1d095f5R1-R51): Introduced a temporary polyfill for `performance.now()` in Node.js, including licensing information and implementation details.