### PR TITLE
fix: adjustments in the domain and firewall processing transform config

### DIFF
--- a/packages/config/src/configProcessor/helpers/schemaManifest.ts
+++ b/packages/config/src/configProcessor/helpers/schemaManifest.ts
@@ -475,11 +475,9 @@ const schemaFirewallManifest = {
       errorMessage: "The 'rules' field must be an array of firewall rules.",
     },
   },
-  required: ['main_settings'],
   additionalProperties: false,
   errorMessage: {
-    additionalProperties: 'No additional properties are allowed in firewall items.',
-    required: "The 'main_settings' field is required in each firewall item.",
+    additionalProperties: 'No additional properties are allowed in firewall object.',
   },
 };
 
@@ -797,9 +795,7 @@ const schemaManifest = {
       errorMessage: "The 'domains' field must be an array of domain items.",
     },
     firewall: {
-      type: 'array',
-      items: schemaFirewallManifest,
-      errorMessage: "The 'firewall' field must be an array of firewall items.",
+      ...schemaFirewallManifest,
     },
     application: {
       type: 'array',

--- a/packages/config/src/configProcessor/processStrategy/implementations/domainProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/domainProcessConfigStrategy.ts
@@ -63,11 +63,13 @@ class DomainProcessConfigStrategy extends ProcessConfigStrategy {
       digitalCertificateId: domain.digital_certificate_id,
       edgeApplicationId: domain.edge_application_id,
       edgeFirewallId: domain.edge_firewall_id,
-      mtls: {
-        verification: domain.mtls_verification,
-        trustedCaCertificateId: domain.mtls_trusted_ca_certificate_id,
-        crlList: domain.crl_list,
-      },
+      mtls: domain.mtls_verification
+        ? {
+            verification: domain.mtls_verification,
+            trustedCaCertificateId: domain.mtls_trusted_ca_certificate_id,
+            crlList: domain.crl_list,
+          }
+        : undefined,
     };
     return transformedPayload.domain;
   }

--- a/packages/config/src/configProcessor/processStrategy/implementations/secure/firewallProcessConfigStrategy.test.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/secure/firewallProcessConfigStrategy.test.ts
@@ -253,7 +253,7 @@ describe('FirewallProcessConfigStrategy', () => {
       const manifest = {};
       const config = {};
       const result = strategy.transformToConfig(manifest, config);
-      expect(result).toBeUndefined();
+      expect(result).toStrictEqual(expect.objectContaining({}));
     });
 
     it('should transform all behavior types from manifest to config', () => {
@@ -299,7 +299,8 @@ describe('FirewallProcessConfigStrategy', () => {
       };
 
       const config = {};
-      const result = strategy.transformToConfig(manifest, config);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result: any = strategy.transformToConfig(manifest, config);
       expect(result?.rules?.[0].behavior).toEqual({
         runFunction: {
           path: '/edge/function.js',
@@ -336,7 +337,8 @@ describe('FirewallProcessConfigStrategy', () => {
       };
 
       const config = {};
-      const result = strategy.transformToConfig(manifest, config);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result: any = strategy.transformToConfig(manifest, config);
       expect(result?.rules?.[0].behavior).toEqual({});
     });
 
@@ -360,7 +362,8 @@ describe('FirewallProcessConfigStrategy', () => {
       };
 
       const config = {};
-      const result = strategy.transformToConfig(manifest, config);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result: any = strategy.transformToConfig(manifest, config);
       expect(result?.rules?.[0].behavior).toEqual({});
     });
   });

--- a/packages/config/src/configProcessor/processStrategy/implementations/secure/firewallProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/secure/firewallProcessConfigStrategy.ts
@@ -121,8 +121,8 @@ class FirewallProcessConfigStrategy extends ProcessConfigStrategy {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transformToConfig(payload: any, transformedPayload: AzionConfig) {
     const firewall = payload.firewall;
-    if (!firewall) {
-      return;
+    if (!firewall || Object.keys(firewall).length === 0) {
+      return {};
     }
 
     const firewallConfig: AzionFirewall = {


### PR DESCRIPTION
This pull request includes several changes aimed at improving the configuration processing and testing for firewall and domain configurations. The most important changes include updates to the schema manifest, adjustments in the domain and firewall processing strategies, and modifications to the test cases.

### Schema Manifest Updates:
* [`packages/config/src/configProcessor/helpers/schemaManifest.ts`](diffhunk://#diff-9a4bca5c0ce3364aea1bda2adeebd9bb4b269b1379b53d3f7bfe021d31bd695cL478-R480): Simplified the `firewall` schema by spreading `schemaFirewallManifest` and updated error messages for additional properties. [[1]](diffhunk://#diff-9a4bca5c0ce3364aea1bda2adeebd9bb4b269b1379b53d3f7bfe021d31bd695cL478-R480) [[2]](diffhunk://#diff-9a4bca5c0ce3364aea1bda2adeebd9bb4b269b1379b53d3f7bfe021d31bd695cL800-R798)

### Domain Processing Strategy Adjustments:
* [`packages/config/src/configProcessor/processStrategy/implementations/domainProcessConfigStrategy.ts`](diffhunk://#diff-ce6f430a0e195916e91c8a81c0953e7539161f46cd1c9b04295972ed706bf5beL66-R72): Modified the `mtls` field to conditionally include `mtls_verification` properties only if they are defined.

### Firewall Processing Strategy Adjustments:
* [`packages/config/src/configProcessor/processStrategy/implementations/secure/firewallProcessConfigStrategy.ts`](diffhunk://#diff-d7fcf863d8b53cc0ac2ea6825c7e53e79b548235331c00c4e721cfcfb7bd32e1L124-R125): Enhanced the `transformToConfig` method to return an empty object if the `firewall` payload is empty or undefined.

### Test Case Modifications:
* [`packages/config/src/configProcessor/processStrategy/implementations/secure/firewallProcessConfigStrategy.test.ts`](diffhunk://#diff-972d72cf5b20afc62b456a696efa72c5e3c5e76011df95b93439261f657f5e2aL256-R256): Updated test cases to use `expect.objectContaining({})` and added type annotations to avoid TypeScript linting errors. [[1]](diffhunk://#diff-972d72cf5b20afc62b456a696efa72c5e3c5e76011df95b93439261f657f5e2aL256-R256) [[2]](diffhunk://#diff-972d72cf5b20afc62b456a696efa72c5e3c5e76011df95b93439261f657f5e2aL302-R303) [[3]](diffhunk://#diff-972d72cf5b20afc62b456a696efa72c5e3c5e76011df95b93439261f657f5e2aL339-R341) [[4]](diffhunk://#diff-972d72cf5b20afc62b456a696efa72c5e3c5e76011df95b93439261f657f5e2aL363-R366)