### PR TITLE
fix: add Azion.Storage to globalThis for polyfill

### DIFF
--- a/packages/bundler/src/helpers/azion-local-polyfills.ts
+++ b/packages/bundler/src/helpers/azion-local-polyfills.ts
@@ -13,5 +13,6 @@ export default {
     ['azion:storage', `${externalPolyfillsPath}/storage/storage.polyfills.js`],
     ['Azion.env', `${externalPolyfillsPath}/env-vars/env-vars.polyfills.js`],
     ['Azion.networkList', `${externalPolyfillsPath}/network-list/network-list.polyfills.js`],
+    ['Azion.Storage', `${externalPolyfillsPath}/storage/storage.polyfills.js`],
   ]),
 };

--- a/packages/bundler/src/polyfills/azion/storage/storage.polyfills.js
+++ b/packages/bundler/src/polyfills/azion/storage/storage.polyfills.js
@@ -197,3 +197,6 @@ export class StorageObjectList {
     this.entries = list;
   }
 }
+
+globalThis.Azion = globalThis.Azion || {};
+globalThis.Azion.Storage = Storage;


### PR DESCRIPTION
This pull request introduces changes to enhance Azion-related polyfills by adding support for the `Azion.Storage` global object. The changes ensure that `Azion.Storage` is properly initialized and linked to the corresponding polyfill.

### Enhancements to Azion polyfills:

* [`packages/bundler/src/helpers/azion-local-polyfills.ts`](diffhunk://#diff-a534d27256a11d79145f29a7a133a8445b64f7430ef15654acc5a547a620a807R16): Added a mapping for `Azion.Storage` to the `storage.polyfills.js` file, ensuring the polyfill is included in the bundler.
* [`packages/bundler/src/polyfills/azion/storage/storage.polyfills.js`](diffhunk://#diff-46dc1fbd1c625240135d0f56b0838bc09672f625b2b86d76a58f15a293598f1bR200-R202): Initialized `globalThis.Azion.Storage` with the `Storage` class, ensuring the `Azion.Storage` global object is available and functional.