### PR TITLE
fix: streamline stream polyfills and enhance process, module, setInterval

### DIFF
--- a/packages/bundler/src/polyfills/stream/context/stream.context.js
+++ b/packages/bundler/src/polyfills/stream/context/stream.context.js
@@ -1,21 +1,16 @@
 /* eslint-disable */
 import stream from 'node:stream';
 
-export var { Duplex } = stream;
-export var { Writable } = stream;
-export var { Readable } = stream;
-export var { Transform } = stream;
-export var { PassThrough } = stream;
-export var { Stream } = stream;
-export var { prototype } = stream;
+const localStream = {};
+export const { Duplex, Writable, Readable, Transform, PassThrough, Stream } = stream;
+export const { prototype } = stream;
 
-export default {
-  Duplex,
-  Writable,
-  Readable,
-  Transform,
-  PassThrough,
-  Stream,
-  stream,
-  prototype,
-};
+localStream.Duplex = Duplex;
+localStream.Writable = Writable;
+localStream.Readable = Readable;
+localStream.Transform = Transform;
+localStream.PassThrough = PassThrough;
+localStream.Stream = Stream;
+localStream.prototype = prototype;
+
+export default localStream;

--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -12,7 +12,8 @@ export default {
     __dirname: `${polyfillsPath}/node/globals/path-dirname.js`,
     __filename: `${polyfillsPath}/node/globals/path-filename.js`,
     process: `${polyfillsPath}/node/globals/process.cjs`,
-    performance: `${polyfillsPath}/node/globals/performance.js`,
+    performance: `unenv/polyfill/performance`,
+    setInterval: `${polyfillsPath}/node/globals/set-interval.js`,
   },
   alias: {
     'azion/utils': 'azion/utils',

--- a/packages/unenv-preset/src/polyfills/node/globals/process.cjs
+++ b/packages/unenv-preset/src/polyfills/node/globals/process.cjs
@@ -1,5 +1,7 @@
 /* eslint-disable */
 // shim for using process in browser
+globalThis.startTime = globalThis.startTime || Date.now();
+
 var processShim = (module.exports = {});
 
 /*
@@ -188,6 +190,10 @@ processShim.removeAllListeners = noop;
 processShim.emit = noop;
 processShim.prependListener = noop;
 processShim.prependOnceListener = noop;
+
+processShim.uptime = function () {
+  return (Date.now() - globalThis.startTime) / 1000;
+};
 
 processShim.listeners = function (name) {
   return [];

--- a/packages/unenv-preset/src/polyfills/node/globals/set-interval.js
+++ b/packages/unenv-preset/src/polyfills/node/globals/set-interval.js
@@ -1,0 +1,21 @@
+const _setInterval = globalThis.setInterval;
+const _clearInterval = globalThis.clearInterval;
+
+globalThis.setInterval = (...args) => {
+  const id = _setInterval(...args);
+  if (typeof id === 'object' && id !== null) {
+    // this is necessary for compatibility with the Sentry library and node's timers
+    if (typeof id.unref !== 'function') {
+      id.unref = () => {};
+    }
+    return id;
+  }
+  return {
+    id,
+    unref: () => {},
+    ref: () => {},
+    clear: () => _clearInterval(id),
+  };
+};
+
+export default globalThis.setInterval;

--- a/packages/unenv-preset/src/polyfills/node/module.js
+++ b/packages/unenv-preset/src/polyfills/node/module.js
@@ -8,7 +8,7 @@ function unimplemented() {
   throw new Error('Not implemented yet!');
 }
 
-const builtinModules = [
+var builtinModules = [
   '_http_agent',
   '_http_client',
   '_http_common',
@@ -84,34 +84,72 @@ function _nodeModulePaths(...args) {
   /* EMPTY */
 }
 
-// Crie um objeto para exportação
-const moduleExports = {
-  builtinModules: builtinModules,
-  _cache: null,
-  _pathCache: null,
-  _extensions: null,
-  globalPaths: null,
-  _debug: unimplemented,
-  _findPath: unimplemented,
-  _nodeModulePaths: _nodeModulePaths,
-  _resolveLookupPaths: unimplemented,
-  _load: _load,
+function _resolveFilename(...args) {
+  /* EMPTY */
+}
+
+const Module = {};
+
+// Adicione as propriedades estáticas esperadas
+Module.builtinModules = builtinModules;
+Module._cache = null;
+Module._pathCache = null;
+Module._extensions = null;
+Module.globalPaths = null;
+Module._debug = unimplemented;
+Module._findPath = unimplemented;
+Module._nodeModulePaths = _nodeModulePaths;
+Module._resolveLookupPaths = unimplemented;
+Module._load = _load;
+Module._resolveFilename = _resolveFilename;
+Module.createRequireFromPath = unimplemented;
+Module.createRequire = createRequire;
+Module._initPaths = unimplemented;
+Module._preloadModules = unimplemented;
+Module.syncBuiltinESMExports = unimplemented;
+Module.runMain = unimplemented;
+Module.findSourceMap = unimplemented;
+Module.SourceMap = unimplemented;
+Module.require = unimplemented;
+const _prototype = {
+  require: unimplemented,
+  resolve: unimplemented,
+  paths: [],
+  id: '',
+  filename: '',
+  loaded: false,
+  children: [],
+  exports: {},
+  _compile: unimplemented,
   _resolveFilename: unimplemented,
-  createRequireFromPath: unimplemented,
-  createRequire: createRequire,
-  _initPaths: unimplemented,
-  _preloadModules: unimplemented,
-  syncBuiltinESMExports: unimplemented,
-  Module: unimplemented,
-  runMain: unimplemented,
-  findSourceMap: unimplemented,
-  SourceMap: unimplemented,
 };
 
-Object.defineProperty(moduleExports, '_resolveFilename', {
-  value: unimplemented,
-  writable: true,
-  configurable: true,
-});
+export default Module;
 
-export default moduleExports;
+export var _cache = null,
+  _pathCache = null,
+  _extensions = null,
+  globalPaths = null;
+
+export {
+  unimplemented as _debug,
+  unimplemented as _findPath,
+  unimplemented as _initPaths,
+  unimplemented as _load,
+  unimplemented as _nodeModulePaths,
+  unimplemented as _preloadModules,
+  unimplemented as _resolveFilename,
+  unimplemented as _resolveLookupPaths,
+  builtinModules,
+  createRequire as createRequire,
+  createRequire as createRequireFromPath,
+  unimplemented as findSourceMap,
+  Module,
+  _prototype as prototype,
+  unimplemented as require,
+  unimplemented as runMain,
+  unimplemented as SourceMap,
+  unimplemented as syncBuiltinESMExports,
+};
+
+/* eslint-enable */


### PR DESCRIPTION
This pull request introduces several updates to polyfills and module handling across the codebase, focusing on improving compatibility, restructuring exports, and enhancing functionality. Key changes include refactoring the `stream` polyfills, adding new polyfills for `setInterval` and `process.uptime`, and restructuring the `Module` polyfill for better alignment with Node.js behavior.

### Stream Polyfills Refactoring:
* Refactored `stream.context.js` to use a `localStream` object for managing stream types and their exports, simplifying the structure and improving encapsulation. (`[packages/bundler/src/polyfills/stream/context/stream.context.jsL4-R16](diffhunk://#diff-8009e89b001c18478e6d44348627034134f8e65f8cdbff1a37a74d8c2168141dL4-R16)`)
* Updated `stream.polyfills.js` to enhance the `Readable.toWeb` method with proper cleanup of event listeners and added a `Writable.fromWeb` method for compatibility with web streams. (`[[1]](diffhunk://#diff-0b1a2b0e278265f900e651f94218447cc5b3532f647b7250e840bfe7c3d0ed41L2-R57)`, `[[2]](diffhunk://#diff-0b1a2b0e278265f900e651f94218447cc5b3532f647b7250e840bfe7c3d0ed41L48-R85)`, `[[3]](diffhunk://#diff-0b1a2b0e278265f900e651f94218447cc5b3532f647b7250e840bfe7c3d0ed41L95-R129)`)

### New Polyfills:
* Introduced a polyfill for `setInterval` to ensure compatibility with libraries like Sentry by adding `unref` and `ref` methods to the returned object. (`[packages/unenv-preset/src/polyfills/node/globals/set-interval.jsR1-R21](diffhunk://#diff-759dc6139dfdef6533e9e074cc8f702a9b82ffffc765cbc827cbebae301ddc6eR1-R21)`)
* Added `process.uptime` to the `process` polyfill, calculating uptime based on a global `startTime`. (`[[1]](diffhunk://#diff-4f9211a326dd4f40bdb7d63f99be7fc9873aa2446e6423e8bf9ab8eb9e59904aR3-R4)`, `[[2]](diffhunk://#diff-4f9211a326dd4f40bdb7d63f99be7fc9873aa2446e6423e8bf9ab8eb9e59904aR194-R197)`)

### Module Polyfill Restructuring:
* Reorganized the `Module` polyfill, replacing the previous export object with a more structured `Module` object that includes static properties and methods, aligning it more closely with Node.js's module system. (`[[1]](diffhunk://#diff-3d740d5b47fd36e31cfb4156fc9d134df6fee7e1f61d77c347be87435ba73ebeL11-R11)`, `[[2]](diffhunk://#diff-3d740d5b47fd36e31cfb4156fc9d134df6fee7e1f61d77c347be87435ba73ebeL87-R155)`)

### Other Updates:
* Updated the `performance` polyfill path in the `unenv-preset` package to use a new location (`unenv/polyfill/performance`). (`[packages/unenv-preset/src/index.tsL15-R16](diffhunk://#diff-40a0c89863390a48518ad7870d9042ad049b987f88f48b67368e0b4f9570a450L15-R16)`)