### PR TITLE
fix: polyfills for Node.js compatibility

### DIFF
--- a/packages/bundler/src/polyfills/promises/index.js
+++ b/packages/bundler/src/polyfills/promises/index.js
@@ -4,4 +4,4 @@
  */
 import promisesContext from './context/index.js';
 
-export default { promisesContext };
+export default promisesContext;

--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -26,6 +26,8 @@ export default {
     module: `${polyfillsPath}/node/module.js`,
     string_decoder: 'string_decoder/lib/string_decoder.js',
     timers: 'timers-browserify/',
+    util: `${polyfillsPath}/node/util.js`,
+    'util/types': `${polyfillsPath}/node/internal/util/types.js`,
   },
   external: ['node:async_hooks', 'node:fs/promises', 'node:stream', 'node:crypto'],
   polyfill: [

--- a/packages/unenv-preset/src/polyfills/node/internal/_internal.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/_internal.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export function notImplemented(name) {
+  const fn = () => {
+    throw createNotImplementedError(name);
+  };
+  return Object.assign(fn, { __unenv__: true });
+}
+
+export function createNotImplementedError(name) {
+  return new Error(`[unenv] ${name} is not implemented yet!`);
+}

--- a/packages/unenv-preset/src/polyfills/node/internal/util/inherits.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/util/inherits.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export function inherits(ctor, superCtor) {
+  if (!superCtor) {
+    return;
+  }
+  ctor.super_ = superCtor;
+  ctor.prototype = Object.create(superCtor.prototype, {
+    constructor: {
+      value: ctor,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+  });
+}

--- a/packages/unenv-preset/src/polyfills/node/internal/util/legacy-types.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/util/legacy-types.js
@@ -1,0 +1,51 @@
+/* eslint-disable */
+export const isRegExp = (val) => val instanceof RegExp;
+
+export const isDate = (val) => val instanceof Date;
+
+export const isArray = (val) => Array.isArray(val);
+
+export const isBoolean = (val) => typeof val === 'boolean';
+
+export const isNull = (val) => val === null;
+
+export const isNullOrUndefined = (val) => val === null || val === undefined;
+
+export const isNumber = (val) => typeof val === 'number';
+
+export const isString = (val) => typeof val === 'string';
+
+export const isSymbol = (val) => typeof val === 'symbol';
+
+export const isUndefined = (val) => val === undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export const isFunction = (val) => typeof val === 'function';
+
+export const isBuffer = (val) => {
+  return (
+    val &&
+    typeof val === 'object' &&
+    typeof val.copy === 'function' &&
+    typeof val.fill === 'function' &&
+    typeof val.readUInt8 === 'function'
+  );
+};
+
+export const isDeepStrictEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+export const isObject = (val) =>
+  val !== null &&
+  typeof val === 'object' &&
+  // eslint-disable-next-line no-prototype-builtins
+  Object.getPrototypeOf(val).isPrototypeOf(Object);
+
+export const isError = (val) => val instanceof Error;
+
+// Source https://github.com/jonschlinkert/is-primitive/blob/b22c524da5cbac075f14145780ec4b3637afd7dc/index.js
+export const isPrimitive = (val) => {
+  if (typeof val === 'object') {
+    return val === null;
+  }
+  return typeof val !== 'function';
+};

--- a/packages/unenv-preset/src/polyfills/node/internal/util/log.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/util/log.js
@@ -1,0 +1,64 @@
+/* eslint-disable */
+export const log = (...args) => {
+  console.log(...args);
+};
+
+export const debuglog = (section, _cb) => {
+  const fn = (msg, ...params) => {
+    if (fn.enabled) {
+      console.debug(`[${section}] ${msg}`, ...params);
+    }
+  };
+  fn.enabled = true;
+  return fn;
+};
+
+export const debug = debuglog;
+
+export const inspect = (object) => JSON.stringify(object, null, 2);
+
+export const format = (...args) => _format(...args);
+
+export const formatWithOptions = (_options, ...args) => _format(...args);
+
+// Source: https://github.com/tmpfs/format-util/blob/0c989942c959b179eec294a4e725afd63e743f18/format.js
+function _format(fmt, ...args) {
+  const re = /(%?)(%([djos]))/g;
+  if (args.length > 0) {
+    fmt = fmt.replace(re, (match, escaped, ptn, flag) => {
+      let arg = args.shift();
+      switch (flag) {
+        case 'o':
+          if (Array.isArray(arg)) {
+            arg = JSON.stringify(arg);
+            break;
+          }
+          break;
+        case 's':
+          arg = '' + arg;
+          break;
+        case 'd':
+          arg = Number(arg);
+          break;
+        case 'j':
+          arg = JSON.stringify(arg);
+          break;
+      }
+      if (!escaped) {
+        return arg;
+      }
+      args.unshift(arg);
+      return match;
+    });
+  }
+
+  // arguments remain after formatting
+  if (args.length > 0) {
+    fmt += ' ' + args.join(' ');
+  }
+
+  // update escaped %% values
+  fmt = fmt.replace(/%{2}/g, '%');
+
+  return '' + fmt;
+}

--- a/packages/unenv-preset/src/polyfills/node/internal/util/mime.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/util/mime.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+// https://nodejs.org/api/util.html#class-utilmimetype
+
+export class MIMEType {
+  __unenv__ = true;
+
+  params = new MIMEParams();
+  type;
+  subtype;
+
+  constructor(input) {
+    const [essence = '', ...params] = String(input).split(';');
+    const [type = '', subtype = ''] = essence.split('/');
+    this.type = type;
+    this.subtype = subtype;
+    this.params = new MIMEParams();
+    for (const param of params) {
+      const [name, value] = param.split('=');
+      this.params.set(name, value);
+    }
+  }
+
+  get essence() {
+    return this.type + '/' + this.subtype;
+  }
+
+  toString() {
+    const paramsStr = this.params.toString();
+    return this.essence + (paramsStr ? `;${paramsStr}` : '');
+  }
+}
+
+// https://nodejs.org/api/util.html#util_class_util_mimeparams
+
+export class MIMEParams extends Map {
+  __unenv__ = true;
+
+  get(name) {
+    return super.get(name) || null;
+  }
+
+  toString() {
+    return [...this.entries()].map(([name, value]) => `${name}=${value}`).join('&');
+  }
+}

--- a/packages/unenv-preset/src/polyfills/node/internal/util/promisify.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/util/promisify.js
@@ -1,0 +1,25 @@
+/* eslint-disable */
+const customSymbol = Symbol.for('nodejs.util.promisify.custom');
+
+function _promisify(fn) {
+  if (fn[customSymbol]) {
+    return fn[customSymbol];
+  }
+  return function (...args) {
+    return new Promise((resolve, reject) => {
+      try {
+        fn.call(this, ...args, (err, val) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(val);
+        });
+      } catch (error) {
+        console.error('Error in promisified function:', error.stack);
+        reject(error);
+      }
+    });
+  };
+}
+
+export const promisify = Object.assign(_promisify, { custom: customSymbol });

--- a/packages/unenv-preset/src/polyfills/node/internal/util/types.js
+++ b/packages/unenv-preset/src/polyfills/node/internal/util/types.js
@@ -1,0 +1,131 @@
+/* eslint-disable */
+import { notImplemented } from '../_internal.js';
+
+export const isExternal = (_obj) => false;
+
+export const isDate = (val) => val instanceof Date;
+
+export const isArgumentsObject = /*@__PURE__*/ notImplemented('util.types.isArgumentsObject');
+
+export const isBigIntObject = (val) => val instanceof BigInt;
+
+export const isBooleanObject = (val) => val instanceof Boolean;
+
+export const isNumberObject = (val) => val instanceof Number;
+
+export const isStringObject = (val) => val instanceof String;
+
+export const isSymbolObject = (val) => val instanceof Symbol;
+
+export const isNativeError = /*@__PURE__*/ notImplemented('util.types.isNativeError');
+
+export const isRegExp = (val) => val instanceof RegExp;
+
+export const isAsyncFunction = /*@__PURE__*/ notImplemented('util.types.isAsyncFunction');
+
+export const isGeneratorFunction = /*@__PURE__*/ notImplemented('util.types.isGeneratorFunction');
+
+export const isGeneratorObject = /*@__PURE__*/ notImplemented('util.types.isGeneratorObject');
+
+export const isPromise = (val) => val instanceof Promise;
+
+export const isMap = (val) => val instanceof Map;
+
+export const isSet = (val) => val instanceof Set;
+
+export const isMapIterator = /*@__PURE__*/ notImplemented('util.types.isMapIterator');
+
+export const isSetIterator = /*@__PURE__*/ notImplemented('util.types.isSetIterator');
+
+export const isWeakMap = (val) => val instanceof WeakMap;
+
+export const isWeakSet = (val) => val instanceof WeakSet;
+
+export const isArrayBuffer = (val) => val instanceof ArrayBuffer;
+
+export const isDataView = (val) => val instanceof DataView;
+
+export const isSharedArrayBuffer = (val) => val instanceof SharedArrayBuffer;
+
+export const isProxy = /*@__PURE__*/ notImplemented('util.types.isProxy');
+
+export const isModuleNamespaceObject = /*@__PURE__*/ notImplemented('util.types.isModuleNamespaceObject');
+
+export const isAnyArrayBuffer = /*@__PURE__*/ notImplemented('util.types.isAnyArrayBuffer');
+
+export const isBoxedPrimitive = /*@__PURE__*/ notImplemented('util.types.isBoxedPrimitive');
+
+export const isArrayBufferView = /*@__PURE__*/ notImplemented('util.types.isArrayBufferView');
+
+export const isTypedArray = /*@__PURE__*/ notImplemented('util.types.isTypedArray');
+
+export const isUint8Array = /*@__PURE__*/ notImplemented('util.types.isUint8Array');
+
+export const isUint8ClampedArray = /*@__PURE__*/ notImplemented('util.types.isUint8ClampedArray');
+
+export const isUint16Array = /*@__PURE__*/ notImplemented('util.types.isUint16Array');
+
+export const isUint32Array = /*@__PURE__*/ notImplemented('util.types.isUint32Array');
+
+export const isInt8Array = /*@__PURE__*/ notImplemented('util.types.isInt8Array');
+
+export const isInt16Array = /*@__PURE__*/ notImplemented('util.types.isInt16Array');
+
+export const isInt32Array = /*@__PURE__*/ notImplemented('util.types.isInt32Array');
+
+export const isFloat32Array = /*@__PURE__*/ notImplemented('util.types.isFloat32Array');
+
+export const isFloat64Array = /*@__PURE__*/ notImplemented('util.types.isFloat64Array');
+
+export const isBigInt64Array = /*@__PURE__*/ notImplemented('util.types.isBigInt64Array');
+
+export const isBigUint64Array = /*@__PURE__*/ notImplemented('util.types.isBigUint64Array');
+
+export const isKeyObject = /*@__PURE__*/ notImplemented('util.types.isKeyObject');
+
+// export const isCryptoKey = /*@__PURE__*/ notImplemented('util.types.isCryptoKey');
+export const isCryptoKey = (val) => typeof CryptoKey !== 'undefined' && val instanceof CryptoKey;
+
+export default {
+  isExternal,
+  isDate,
+  isArgumentsObject,
+  isBigIntObject,
+  isBooleanObject,
+  isNumberObject,
+  isStringObject,
+  isSymbolObject,
+  isNativeError,
+  isRegExp,
+  isAsyncFunction,
+  isGeneratorFunction,
+  isGeneratorObject,
+  isPromise,
+  isMap,
+  isSet,
+  isMapIterator,
+  isSetIterator,
+  isWeakMap,
+  isWeakSet,
+  isArrayBuffer,
+  isDataView,
+  isSharedArrayBuffer,
+  isProxy,
+  isModuleNamespaceObject,
+  isAnyArrayBuffer,
+  isBoxedPrimitive,
+  isArrayBufferView,
+  isTypedArray,
+  isUint8Array,
+  isUint8ClampedArray,
+  isUint16Array,
+  isUint32Array,
+  isInt8Array,
+  isInt16Array,
+  isInt32Array,
+  isFloat32Array,
+  isFloat64Array,
+  isBigInt64Array,
+  isBigUint64Array,
+  isKeyObject, // CryptoKey
+};

--- a/packages/unenv-preset/src/polyfills/node/util.js
+++ b/packages/unenv-preset/src/polyfills/node/util.js
@@ -1,0 +1,130 @@
+/* eslint-disable */
+// https://nodejs.org/api/util.html
+import types from 'node:util/types';
+import { notImplemented } from './internal/_internal.js';
+import { inherits } from './internal/util/inherits.js';
+import {
+  isArray,
+  isBoolean,
+  isBuffer,
+  isDate,
+  isDeepStrictEqual,
+  isError,
+  isFunction,
+  isNull,
+  isNullOrUndefined,
+  isNumber,
+  isObject,
+  isPrimitive,
+  isRegExp,
+  isString,
+  isSymbol,
+  isUndefined,
+} from './internal/util/legacy-types.js';
+import { debug, debuglog, format, formatWithOptions, inspect, log } from './internal/util/log.js';
+import { MIMEParams, MIMEType } from './internal/util/mime.js';
+import { promisify } from './internal/util/promisify.js';
+
+export { MIMEParams, MIMEType } from './internal/util/mime.js';
+
+export * from './internal/util/legacy-types.js';
+
+export * from './internal/util/log.js';
+
+export { inherits } from './internal/util/inherits.js';
+
+export { promisify };
+
+export { default as types } from './internal/util/types.js';
+
+export const TextDecoder = globalThis.TextDecoder;
+
+export const TextEncoder = globalThis.TextEncoder;
+
+export const deprecate = (fn) => fn;
+
+export const _errnoException = notImplemented('util._errnoException');
+
+export const _exceptionWithHostPort = notImplemented('util._exceptionWithHostPort');
+
+export const _extend = notImplemented('util._extend');
+
+export const aborted = notImplemented('util.aborted');
+
+export const callbackify = notImplemented('util.callbackify');
+
+export const getSystemErrorMap = notImplemented('util.getSystemErrorMap');
+
+export const getSystemErrorName = notImplemented('util.getSystemErrorName');
+
+export const toUSVString = notImplemented('util.toUSVString');
+
+export const stripVTControlCharacters = notImplemented('util.stripVTControlCharacters');
+
+export const transferableAbortController = notImplemented('util.transferableAbortController');
+
+export const transferableAbortSignal = notImplemented('util.transferableAbortSignal');
+
+export const parseArgs = notImplemented('util.parseArgs');
+
+export const parseEnv = notImplemented('util.parseEnv');
+
+export const styleText = notImplemented('util.styleText');
+
+/** @deprecated */
+export const getCallSite = notImplemented('util.getCallSite');
+
+export const getCallSites = notImplemented('util.getCallSites');
+
+export const getSystemErrorMessage = notImplemented('util.getSystemErrorMessage');
+
+export default {
+  // @ts-expect-error
+  _errnoException,
+  _exceptionWithHostPort,
+  _extend,
+  aborted,
+  callbackify,
+  deprecate,
+  getCallSite,
+  getCallSites,
+  getSystemErrorMessage,
+  getSystemErrorMap,
+  getSystemErrorName,
+  inherits,
+  promisify,
+  stripVTControlCharacters,
+  toUSVString,
+  TextDecoder,
+  TextEncoder,
+  types,
+  transferableAbortController,
+  transferableAbortSignal,
+  parseArgs,
+  parseEnv,
+  styleText,
+  MIMEParams,
+  MIMEType,
+  isArray,
+  isBoolean,
+  isBuffer,
+  isDate,
+  isDeepStrictEqual,
+  isError,
+  isFunction,
+  isNull,
+  isNullOrUndefined,
+  isNumber,
+  isObject,
+  isPrimitive,
+  isRegExp,
+  isString,
+  isSymbol,
+  isUndefined,
+  debug,
+  debuglog,
+  format,
+  formatWithOptions,
+  inspect,
+  log,
+};


### PR DESCRIPTION
This pull request introduces significant updates to the `unenv-preset` package, focusing on enhancing Node.js polyfills and improving the `https` request implementation. It also includes some minor code simplifications and reorganization. Below is a categorized summary of the most important changes:

### Enhancements to Node.js Polyfills:
* Added a comprehensive set of utility functions and classes in `internal/util` to mimic Node.js behavior, including `inherits`, `MIMEType`, `MIMEParams`, `promisify`, and various type-checking utilities like `isRegExp` and `isDate`. These updates improve compatibility with Node.js APIs. [[1]](diffhunk://#diff-a80b3a3840b7fe8f11677d198b841d1ce438f3dfd116131aaeff1003d41046a4R1-R15) [[2]](diffhunk://#diff-9ada7be1bf71d6560d64a4488c3ea07932e6ba358374ab4a9917a4f457b1cdacR1-R45) [[3]](diffhunk://#diff-e778902d32020fa64a083044cd915f34b27b3666ef042343e03bc99cee9297a6R1-R25) [[4]](diffhunk://#diff-5cd2f9f01aea009e00f67ceab5054fc3faba4511dd64ae9fddb3d3faf6ad4193R1-R51) [[5]](diffhunk://#diff-0aa41b781602af9fa464e24e4a26e848b707ddc4d442b907ac30a50670d09eb2R1-R131)
* Introduced a new `util.js` file that consolidates exports from `internal/util`, providing a single entry point for utility functions and polyfills.

### Improvements to `https` Request Implementation:
* Refactored the `request` function in `https.js` to support additional options (`urlOrOptions` and `optionsOrCallback`) and handle headers, methods, and body formatting more robustly.
* Added support for setting and removing headers dynamically via `setHeader` and `removeHeader` methods.
* Enhanced response handling by implementing an async iterator for streaming response data and improving chunk processing.
* Made the timeout duration configurable via the `options.timeout` parameter.

### Code Simplifications and Minor Changes:
* Simplified the default export in `polyfills/promises/index.js` by directly exporting `promisesContext`.
* Added new polyfill paths for `util` and `util/types` in the `unenv-preset` configuration.

These changes collectively enhance the functionality and compatibility of the `unenv-preset` package, particularly for environments requiring Node.js polyfills.