### PR TITLE
fix: add polyfill for clearInterval and update injection in unenv preset

### DIFF
--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -14,6 +14,7 @@ export default {
     process: `${polyfillsPath}/node/globals/process.cjs`,
     performance: `unenv/polyfill/performance`,
     setInterval: `${polyfillsPath}/node/globals/set-interval.js`,
+    clearInterval: `${polyfillsPath}/node/globals/clear-interval.js`,
   },
   alias: {
     'azion/utils': 'azion/utils',
@@ -27,7 +28,6 @@ export default {
     string_decoder: 'string_decoder/lib/string_decoder.js',
     timers: 'timers-browserify/',
     util: `${polyfillsPath}/node/util.js`,
-    'util/types': `${polyfillsPath}/node/internal/util/types.js`,
   },
   external: ['node:async_hooks', 'node:fs/promises', 'node:stream', 'node:crypto'],
   polyfill: [

--- a/packages/unenv-preset/src/polyfills/node/globals/clear-interval.js
+++ b/packages/unenv-preset/src/polyfills/node/globals/clear-interval.js
@@ -1,0 +1,19 @@
+const _clearInterval = globalThis.clearInterval;
+
+globalThis.clearInterval = (interval) => {
+  let idToClear = interval;
+  if (interval && typeof interval === 'object') {
+    if ('id' in interval) {
+      idToClear = interval.id;
+    } else if ('_id' in interval) {
+      idToClear = interval._id;
+    }
+  }
+  if (typeof idToClear === 'number' && Number.isFinite(idToClear)) {
+    _clearInterval(idToClear);
+  } else if (interval && typeof interval.close === 'function') {
+    interval.close();
+  }
+};
+
+export default globalThis.clearInterval;


### PR DESCRIPTION
This pull request introduces updates to the `unenv-preset` package, including the addition of a polyfill for `clearInterval` and the removal of an unused utility alias. These changes enhance compatibility and simplify the codebase.

### Enhancements to polyfills:

* **Added `clearInterval` polyfill**: Introduced a new polyfill for `clearInterval` in `packages/unenv-preset/src/polyfills/node/globals/clear-interval.js`. This implementation ensures compatibility with various interval object formats by checking for properties like `id`, `_id`, or a `close` method.
* **Registered `clearInterval` in exports**: Added the `clearInterval` polyfill to the `globals` section in `packages/unenv-preset/src/index.ts`.

### Code cleanup:

* **Removed unused alias for `util/types`**: Eliminated the alias for `util/types` in `packages/unenv-preset/src/index.ts`, as it is no longer required.