### PR TITLE
fix: rename skipProjectBuild to skipFrameworkBuild in BuildContext

### DIFF
--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -543,7 +543,7 @@ export interface BundlerSetup {
 export interface BuildContext {
   production: boolean;
   handler: BuildEntryPoint;
-  skipProjectBuild?: boolean;
+  skipFrameworkBuild?: boolean;
 }
 
 export type PresetMetadata = {

--- a/packages/presets/src/presets/opennextjs/prebuild.ts
+++ b/packages/presets/src/presets/opennextjs/prebuild.ts
@@ -27,8 +27,8 @@ async function prebuild(buildConfig: BuildConfiguration, ctx: BuildContext): Pro
     });
   }
   // Run OpenNextjs command build
-  if (ctx.production || !ctx.skipProjectBuild) {
-    const skipBuild = ctx.skipProjectBuild ? '--skipBuild' : '';
+  if (ctx.production || !ctx.skipFrameworkBuild) {
+    const skipBuild = ctx.skipFrameworkBuild ? '--skipBuild' : '';
     await exec(`${openNextjsCommand} build -- ${skipBuild}`, {
       scope: 'OpenNextjs',
       verbose: true,


### PR DESCRIPTION
This pull request updates the naming of a property in the `BuildContext` interface and its usage across the codebase for improved clarity and consistency. The property `skipProjectBuild` has been renamed to `skipFrameworkBuild`.

### Codebase consistency improvements:

* [`packages/config/src/types.ts`](diffhunk://#diff-bc8790029ada0b92644abb2c63a2cfeac3a0854eb92e1e66cd8bb6c9e9428189L546-R546): Renamed the optional property `skipProjectBuild` to `skipFrameworkBuild` in the `BuildContext` interface.
* [`packages/presets/src/presets/opennextjs/prebuild.ts`](diffhunk://#diff-352f0e083b1ae2982427afec2ed79c7bd108b94a5f8a703db8aac284b33632f6L30-R31): Updated references to the renamed property in the `prebuild` function to ensure consistent usage.