### PR TITLE
fix: streamline OpenNextjs prebuild execution by removing conditional checks for production

### DIFF
--- a/packages/presets/src/presets/opennextjs/prebuild.ts
+++ b/packages/presets/src/presets/opennextjs/prebuild.ts
@@ -27,30 +27,20 @@ async function prebuild(buildConfig: BuildConfiguration, ctx: BuildContext): Pro
     });
   }
   // Run OpenNextjs command build
-  if (ctx.production || !ctx.skipFrameworkBuild) {
-    const skipBuild = ctx.skipFrameworkBuild ? '--skipBuild' : '';
-    await exec(`${openNextjsCommand} build -- ${skipBuild}`, {
-      scope: 'OpenNextjs',
-      verbose: true,
-      interactive: true,
-    });
-  }
-
-  // Run OpenNextjs commands to populate assets
-  if (ctx.production) {
-    await exec(`${openNextjsCommand} populateAssets`, {
-      scope: 'OpenNextjs',
-      verbose: true,
-    });
-  }
-
-  // Run OpenNextjs commands to populate cache
-  if (ctx.production) {
-    await exec(`${openNextjsCommand} populateCache`, {
-      scope: 'OpenNextjs',
-      verbose: true,
-    });
-  }
+  const skipBuild = ctx.skipFrameworkBuild ? '--skipBuild' : '';
+  await exec(`${openNextjsCommand} build -- ${skipBuild}`, {
+    scope: 'OpenNextjs',
+    verbose: true,
+    interactive: true,
+  });
+  await exec(`${openNextjsCommand} populateAssets`, {
+    scope: 'OpenNextjs',
+    verbose: true,
+  });
+  await exec(`${openNextjsCommand} populateCache`, {
+    scope: 'OpenNextjs',
+    verbose: true,
+  });
 }
 
 async function checkIfOpenNextjsIsInstalled(): Promise<boolean> {


### PR DESCRIPTION
This pull request simplifies the `prebuild` function in the `OpenNextjs` preset by removing unnecessary conditionals and ensuring all relevant commands are executed unconditionally. 

### Simplification of `prebuild` logic:
* Removed conditional checks (`ctx.production` and `ctx.skipFrameworkBuild`) around the execution of `build`, `populateAssets`, and `populateCache` commands. These commands are now executed unconditionally to streamline the build process. (`[packages/presets/src/presets/opennextjs/prebuild.tsL30-L54](diffhunk://#diff-352f0e083b1ae2982427afec2ed79c7bd108b94a5f8a703db8aac284b33632f6L30-L54)`)