### PR TITLE
fix: dynamically import handleRequest function in Next.js handler

### DIFF
--- a/packages/presets/src/presets/next/handler.ts
+++ b/packages/presets/src/presets/next/handler.ts
@@ -2,7 +2,6 @@
 import { AzionRuntimeCtx, AzionRuntimeRequest } from 'azion/types';
 import { handleImageResizingRequest } from './default/handler/images.js';
 import { adjustRequestForVercel } from './default/handler/routing/http.js';
-import { handleRequest } from './default/handler/routing/index.js';
 import handlerStatic from './static/handler.js';
 
 const getStorageAsset = async (request: Request) => {
@@ -41,7 +40,8 @@ async function main(request: Request, env: Record<string, any>, ctx: any) {
     }
 
     const adjustedRequest = adjustRequestForVercel(request);
-    return handleRequest(
+    const importHandleDefault = await import('./default/handler/routing/index.js');
+    return importHandleDefault.handleRequest(
       {
         request: adjustedRequest,
         ctx,


### PR DESCRIPTION
This pull request refactors the `packages/presets/src/presets/next/handler.ts` file to improve modularity and optimize dynamic imports. The most notable changes include replacing a static import with a dynamic import for the `handleRequest` function and updating the corresponding function call.

### Refactoring for modularity and optimization:
* Removed the static import of `handleRequest` from `./default/handler/routing/index.js` and replaced it with a dynamic import within the `main` function. This change helps reduce the initial load time by only importing the module when needed. [[1]](diffhunk://#diff-c02fa9830240ff535993449f2f37f1175f66f7ab17cb9f468483e7ae5ae2b71eL5) [[2]](diffhunk://#diff-c02fa9830240ff535993449f2f37f1175f66f7ab17cb9f468483e7ae5ae2b71eL44-R44)
* Updated the `handleRequest` function call in the `main` function to use the dynamically imported `handleRequest` from `importHandleDefault`.