### PR TITLE
fix: add getRandomValues, randomUUID and generateKeyPair crypto to runtime dev

### DIFF
--- a/packages/bundler/src/polyfills/crypto/context/crypto.context.js
+++ b/packages/bundler/src/polyfills/crypto/context/crypto.context.js
@@ -32,6 +32,9 @@ export var { publicEncrypt } = crypto;
 export var { randomBytes } = crypto;
 export var { randomFill } = crypto;
 export var { randomFillSync } = crypto;
+export var { getRandomValues } = crypto;
+export var { randomUUID } = crypto;
+export var { generateKeyPair } = crypto;
 
 export default {
   Cipher,
@@ -65,4 +68,7 @@ export default {
   randomBytes,
   randomFill,
   randomFillSync,
+  getRandomValues,
+  randomUUID,
+  generateKeyPair,
 };

--- a/packages/bundler/src/polyfills/crypto/crypto.polyfills.js
+++ b/packages/bundler/src/polyfills/crypto/crypto.polyfills.js
@@ -37,6 +37,9 @@ export var { publicEncrypt } = CRYPTO_CONTEXT.cryptoContext;
 export var { randomBytes } = CRYPTO_CONTEXT.cryptoContext;
 export var { randomFill } = CRYPTO_CONTEXT.cryptoContext;
 export var { randomFillSync } = CRYPTO_CONTEXT.cryptoContext;
+export var { getRandomValues } = CRYPTO_CONTEXT.cryptoContext;
+export var { randomUUID } = CRYPTO_CONTEXT.cryptoContext;
+export var { generateKeyPair } = CRYPTO_CONTEXT.cryptoContext;
 
 export default {
   Cipher,
@@ -70,4 +73,7 @@ export default {
   randomBytes,
   randomFill,
   randomFillSync,
+  getRandomValues,
+  randomUUID,
+  generateKeyPair,
 };


### PR DESCRIPTION
This pull request enhances the crypto polyfills in the `packages/bundler` module by adding support for additional cryptographic methods. These updates ensure feature parity with the native `crypto` module and improve compatibility with modern JavaScript environments.

### Additions to crypto polyfills:

* [`packages/bundler/src/polyfills/crypto/context/crypto.context.js`](diffhunk://#diff-f765e573e23c3f42eb4cb11274d8d0c0f475241e577874a9c995ae727c0e368dR35-R37): Added `getRandomValues`, `randomUUID`, and `generateKeyPair` to the `crypto` context exports and included them in the default export object. [[1]](diffhunk://#diff-f765e573e23c3f42eb4cb11274d8d0c0f475241e577874a9c995ae727c0e368dR35-R37) [[2]](diffhunk://#diff-f765e573e23c3f42eb4cb11274d8d0c0f475241e577874a9c995ae727c0e368dR71-R73)

* [`packages/bundler/src/polyfills/crypto/crypto.polyfills.js`](diffhunk://#diff-e7ba8efda82ad815ab5ad1915d8f1dce8097bec25b9aceb0ad084397d98d093cR40-R42): Added `getRandomValues`, `randomUUID`, and `generateKeyPair` to the `cryptoContext` exports and included them in the default export object. [[1]](diffhunk://#diff-e7ba8efda82ad815ab5ad1915d8f1dce8097bec25b9aceb0ad084397d98d093cR40-R42) [[2]](diffhunk://#diff-e7ba8efda82ad815ab5ad1915d8f1dce8097bec25b9aceb0ad084397d98d093cR76-R78)