### PR TITLE
fix: update storage paths and enable edge functions by default across presets

### DIFF
--- a/packages/bundler/src/polyfills/azion/fetch/context/fetch.context.js
+++ b/packages/bundler/src/polyfills/azion/fetch/context/fetch.context.js
@@ -20,16 +20,17 @@ function getUrlFromResource(context, resource) {
  * @param {object} context - The context object.
  * @param {URL|Request|string} resource - The resource to fetch.
  * @param {object} [options] - The fetch options.
+ * @param {string} pathBucket - The path to the storage bucket.
  * @returns {Promise<Response>} A Promise that resolves to the Response object.
  */
-async function fetchContext(context, resource, options) {
+async function fetchContext(context, resource, options, pathBucket = '') {
   const { Headers, Response, RESERVED_FETCH } = context;
 
   const urlObj = getUrlFromResource(context, resource);
 
   if (urlObj.href.startsWith('file://')) {
     const file = urlObj.pathname;
-    const filePath = join(process.cwd(), '.edge', 'storage', file);
+    const filePath = join(process.cwd(), '.edge', 'storage', pathBucket, file);
 
     const fileContent = readFileSync(filePath);
     const contentType = mime.lookup(filePath) || 'application/octet-stream';

--- a/packages/config/src/configProcessor/processStrategy/implementations/application/edgeApplicationProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/application/edgeApplicationProcessConfigStrategy.ts
@@ -27,7 +27,7 @@ class EdgeApplicationProcessConfigStrategy extends ProcessConfigStrategy {
             enabled: app.edgeCacheEnabled ?? true,
           },
           edge_functions: {
-            enabled: app.edgeFunctionsEnabled ?? false,
+            enabled: app.edgeFunctionsEnabled ?? true,
           },
           application_accelerator: {
             enabled: app.applicationAcceleratorEnabled ?? false,
@@ -82,7 +82,7 @@ class EdgeApplicationProcessConfigStrategy extends ProcessConfigStrategy {
         active: app.active,
         debug: app.debug,
         edgeCacheEnabled: app.modules?.edge_cache?.enabled,
-        edgeFunctionsEnabled: app.modules?.edge_functions?.enabled,
+        edgeFunctionsEnabled: app.modules?.edge_functions?.enabled ?? true,
         applicationAcceleratorEnabled: app.modules?.application_accelerator?.enabled,
         imageProcessorEnabled: app.modules?.image_processor?.enabled,
         tieredCacheEnabled: app.modules?.tiered_cache?.enabled,

--- a/packages/presets/src/presets/angular/config.ts
+++ b/packages/presets/src/presets/angular/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './dist',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,44 @@ const config: AzionConfig = {
       rules: createSPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      domains: [],
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/angular/prebuild.ts
+++ b/packages/presets/src/presets/angular/prebuild.ts
@@ -25,16 +25,16 @@ async function prebuild(): Promise<void> {
   const packageManager: PackageManagerType = await getPackageManager();
   const npmArgsForward: string = packageManager === 'npm' ? '--' : '';
 
-  await exec(`${packageManager} run build ${npmArgsForward} --output-path=.edge/storage`, {
+  await exec(`${packageManager} run build ${npmArgsForward} --output-path=./dist`, {
     scope: 'Angular',
     verbose: true,
   });
 
-  const browserFolder: string = path.join(process.cwd(), '.edge', 'storage', 'browser');
+  const browserFolder: string = path.join(process.cwd(), 'dist', 'browser');
 
   try {
     await fs.access(browserFolder);
-    await moveBrowserFiles(browserFolder, path.join(process.cwd(), '.edge', 'storage'));
+    await moveBrowserFiles(browserFolder, path.join(process.cwd(), 'dist'));
   } catch {
     // Browser folder doesn't exist, nothing to move
   }

--- a/packages/presets/src/presets/javascript/config.ts
+++ b/packages/presets/src/presets/javascript/config.ts
@@ -2,7 +2,7 @@ import type { AzionConfig } from 'azion/config';
 
 const config: AzionConfig = {
   build: {
-    entry: 'handler.js',
+    entry: 'index.js',
   },
   edgeFunctions: [
     {
@@ -40,6 +40,44 @@ const config: AzionConfig = {
           },
         ],
       },
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      domains: [],
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
This pull request introduces several significant updates to the Angular and JavaScript presets, as well as improvements to configuration defaults and the Azion fetch context. The main changes focus on updating build output directories, enhancing configuration with workloads and function instances, and adjusting default behaviors for edge functions.

**Preset and Build Process Updates:**

* Changed the Angular preset's build output directory from `.edge/storage` to `./dist`, updating both the configuration and the prebuild script to reflect this change. This includes moving browser files to the new `dist` directory. [[1]](diffhunk://#diff-0b08b39abf37c25eb06b6ad389c4c159dda7a8f9d6b56c34983fe57f0abbba1fL11-R11) [[2]](diffhunk://#diff-347b372a2e640f0f0b3797c1bf24b73c278111a83930bb58e7bbffcaf48c84caL28-R37)
* Updated the JavaScript preset's build entry point from `handler.js` to `index.js`.

**Configuration Enhancements:**

* Added `functionsInstances` and `workloads` sections to both the Angular and JavaScript preset configurations, enabling more flexible deployment and function management. [[1]](diffhunk://#diff-0b08b39abf37c25eb06b6ad389c4c159dda7a8f9d6b56c34983fe57f0abbba1fR32-R69) [[2]](diffhunk://#diff-7f42cc9f5a58168b8c067a7ce73533416fc87870680133b702bfd608be897b15R43-R80)

**Default Behavior Adjustments:**

* Changed the default for `edgeFunctionsEnabled` to `true` in the edge application process config strategy, ensuring edge functions are enabled unless explicitly disabled. Also, the extraction of this value from modules now defaults to `true` if not set. [[1]](diffhunk://#diff-e87e80b313322035bcdf04a7a074ab00fbff765c36279cc6b256e684ec4d5450L30-R30) [[2]](diffhunk://#diff-e87e80b313322035bcdf04a7a074ab00fbff765c36279cc6b256e684ec4d5450L85-R85)

**Fetch Context Improvement:**

* Modified the Azion fetch context to support an additional `pathBucket` parameter, allowing file access to be scoped within a specific storage bucket path.