### PR TITLE
fix: update presets to use api v4

### DIFF
--- a/packages/config/src/configProcessor/helpers/schema.ts
+++ b/packages/config/src/configProcessor/helpers/schema.ts
@@ -1063,7 +1063,7 @@ const azionConfigSchema = {
                 errorMessage: "The 'deployments' field must be an array of deployment objects",
               },
             },
-            required: ['name', 'domains'],
+            required: ['name'],
             additionalProperties: false,
             errorMessage: {
               additionalProperties: 'No additional properties are allowed in workload items',

--- a/packages/config/src/configProcessor/processStrategy/implementations/application/edgeApplicationProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/application/edgeApplicationProcessConfigStrategy.ts
@@ -27,7 +27,8 @@ class EdgeApplicationProcessConfigStrategy extends ProcessConfigStrategy {
             enabled: app.edgeCacheEnabled ?? true,
           },
           edge_functions: {
-            enabled: app.edgeFunctionsEnabled ?? true,
+            enabled:
+              app.edgeFunctionsEnabled || (app.functionsInstances && app.functionsInstances.length > 0) ? true : false,
           },
           application_accelerator: {
             enabled: app.applicationAcceleratorEnabled ?? false,
@@ -82,7 +83,7 @@ class EdgeApplicationProcessConfigStrategy extends ProcessConfigStrategy {
         active: app.active,
         debug: app.debug,
         edgeCacheEnabled: app.modules?.edge_cache?.enabled,
-        edgeFunctionsEnabled: app.modules?.edge_functions?.enabled ?? true,
+        edgeFunctionsEnabled: app.modules?.edge_functions?.enabled,
         applicationAcceleratorEnabled: app.modules?.application_accelerator?.enabled,
         imageProcessorEnabled: app.modules?.image_processor?.enabled,
         tieredCacheEnabled: app.modules?.tiered_cache?.enabled,

--- a/packages/config/src/configProcessor/processStrategy/implementations/workloadProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/workloadProcessConfigStrategy.ts
@@ -52,7 +52,7 @@ class WorkloadProcessConfigStrategy extends ProcessConfigStrategy {
       active: workload.active,
       infrastructure: workload.infrastructure,
       workloadDomainAllowAccess: workload.workload_domain_allow_access,
-      domains: workload.domains,
+      domains: workload.domains || [],
       tls: {
         certificate: workload.tls?.certificate,
         ciphers: workload.tls?.ciphers,

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -814,7 +814,7 @@ export type AzionWorkload = {
   tls?: AzionWorkloadTLS;
   protocols?: AzionWorkloadProtocols;
   mtls?: AzionWorkloadMTLS;
-  domains: string[];
+  domains?: string[];
   workloadDomainAllowAccess?: boolean;
   /** Workload deployments */
   deployments?: AzionWorkloadDeployment[];

--- a/packages/presets/src/presets/angular/config.ts
+++ b/packages/presets/src/presets/angular/config.ts
@@ -29,15 +29,6 @@ const config: AzionConfig = {
       rules: createSPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
-      functionsInstances: [
-        {
-          name: '$EDGE_FUNCTION_INSTANCE_NAME',
-          ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
-        },
-      ],
     },
   ],
   workloads: [

--- a/packages/presets/src/presets/angular/config.ts
+++ b/packages/presets/src/presets/angular/config.ts
@@ -45,7 +45,6 @@ const config: AzionConfig = {
       name: '$WORKLOAD_NAME',
       active: true,
       infrastructure: 1,
-      domains: [],
       protocols: {
         http: {
           versions: ['http1', 'http2'],

--- a/packages/presets/src/presets/astro/config.ts
+++ b/packages/presets/src/presets/astro/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './dist',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/docusaurus/config.ts
+++ b/packages/presets/src/presets/docusaurus/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './build',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/docusaurus/prebuild.ts
+++ b/packages/presets/src/presets/docusaurus/prebuild.ts
@@ -1,20 +1,24 @@
-import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec, getPackageManager } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Docusaurus
  */
-async function prebuild() {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
   const outDir = 'build';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec(`${packageManager} run build`, {
     scope: 'Docusaurus',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/eleventy/config.ts
+++ b/packages/presets/src/presets/eleventy/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './_site',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/eleventy/prebuild.ts
+++ b/packages/presets/src/presets/eleventy/prebuild.ts
@@ -1,19 +1,23 @@
-import { copyDirectory, exec } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Eleventy
  */
-async function prebuild(): Promise<void> {
-  const newOutDir = '.edge/storage';
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const outDir = '_site';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec(`npx -y @11ty/eleventy`, {
     scope: 'Eleventy',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/emscripten/config.ts
+++ b/packages/presets/src/presets/emscripten/config.ts
@@ -36,7 +36,7 @@ const config: AzionConfig = {
   edgeFunctions: [
     {
       name: '$EDGE_FUNCTION_NAME',
-      path: '$LOCAL_FUNCTION_PATH',
+      path: './functions/handler.js',
     },
   ],
   edgeApplications: [
@@ -69,6 +69,43 @@ const config: AzionConfig = {
           },
         ],
       },
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/gatsby/config.ts
+++ b/packages/presets/src/presets/gatsby/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './public',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/gatsby/prebuild.ts
+++ b/packages/presets/src/presets/gatsby/prebuild.ts
@@ -1,20 +1,24 @@
-import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec, getPackageManager } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Gatsby
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
   const outDir = 'public';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec(`${packageManager} run build`, {
     scope: 'Gatsby',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/hexo/config.ts
+++ b/packages/presets/src/presets/hexo/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './public',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/hexo/prebuild.ts
+++ b/packages/presets/src/presets/hexo/prebuild.ts
@@ -1,13 +1,19 @@
-import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
-import { readFile } from 'fs/promises';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec, getPackageManager } from 'azion/utils/node';
+import { mkdir, readFile } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Hexo
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
   let outDir = 'public';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   // check if an output path is specified in config file
   const configFileContent = await readFile('./_config.yml', 'utf-8');
@@ -21,9 +27,6 @@ async function prebuild(): Promise<void> {
     scope: 'Hexo',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/html/config.ts
+++ b/packages/presets/src/presets/html/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './www',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/html/prebuild.ts
+++ b/packages/presets/src/presets/html/prebuild.ts
@@ -1,15 +1,12 @@
-import { mkdir, rename } from 'fs/promises';
-import { join } from 'path';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for HTML
  */
 async function prebuild(): Promise<void> {
-  const sourceDir = process.cwd();
-  const targetDir = join('.', '.edge', 'storage');
+  const outDir = './www';
 
-  await mkdir(targetDir, { recursive: true });
-  await rename(sourceDir, targetDir);
+  await mkdir(outDir, { recursive: true });
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/hugo/config.ts
+++ b/packages/presets/src/presets/hugo/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './public',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/hugo/prebuild.ts
+++ b/packages/presets/src/presets/hugo/prebuild.ts
@@ -1,21 +1,25 @@
-import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec, getPackageManager } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Hugo
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
   const outDir = 'public';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   const command = packageManager === 'npm' ? 'npx' : packageManager;
   await exec(`${command} hugo`, {
     scope: 'Hugo',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/javascript/config.ts
+++ b/packages/presets/src/presets/javascript/config.ts
@@ -7,7 +7,7 @@ const config: AzionConfig = {
   edgeFunctions: [
     {
       name: '$EDGE_FUNCTION_NAME',
-      path: '$LOCAL_FUNCTION_PATH',
+      path: './functions/index.js', // path to the edge function. This path is relative to the .edge folder.
     },
   ],
   edgeApplications: [
@@ -56,7 +56,6 @@ const config: AzionConfig = {
       name: '$WORKLOAD_NAME',
       active: true,
       infrastructure: 1,
-      domains: [],
       protocols: {
         http: {
           versions: ['http1', 'http2'],

--- a/packages/presets/src/presets/jekyll/config.ts
+++ b/packages/presets/src/presets/jekyll/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './_site',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/jekyll/prebuild.ts
+++ b/packages/presets/src/presets/jekyll/prebuild.ts
@@ -1,19 +1,23 @@
-import { copyDirectory, exec } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Jekyll
  */
-async function prebuild(): Promise<void> {
-  const newOutDir = '.edge/storage';
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const outDir = '_site';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec('bundle install && bundle exec jekyll build', {
     scope: 'Jekyll',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/next/config.ts
+++ b/packages/presets/src/presets/next/config.ts
@@ -7,7 +7,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: '.edge/next-build-assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -25,7 +25,7 @@ const config: AzionConfig = {
   edgeFunctions: [
     {
       name: '$EDGE_FUNCTION_NAME',
-      path: '$LOCAL_FUNCTION_PATH',
+      path: './functions/handler.js',
     },
   ],
   edgeApplications: [
@@ -113,6 +113,43 @@ const config: AzionConfig = {
           },
         ],
       },
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/next/default/prebuild/index.js
+++ b/packages/presets/src/presets/next/default/prebuild/index.js
@@ -62,7 +62,6 @@ function writeOutputReferencesFile(functionsFile, vercelOutput) {
  */
 async function run(prebuildContext) {
   const targetDir = process.cwd();
-  //   const workerDir = join(this.targetDir, '.');
 
   const applicationMapping = {
     invalidFunctions: new Set(),
@@ -73,7 +72,6 @@ async function run(prebuildContext) {
   };
 
   const tmpFunctionsDir = join(tmpdir(), Math.random().toString(36).slice(2));
-  //   const dirName = dirname(__filename);
 
   const config = loadVercelConfigs();
 
@@ -81,10 +79,6 @@ async function run(prebuildContext) {
 
   // adapt functions and set application mapping
   await mapAndAdaptFunctions(applicationMapping, tmpFunctionsDir, prebuildContext?.vcConfigObjects);
-
-  //   if (this.applicationMapping.functionsMap.size <= 0) {
-  //       throw new MiddlewareManifestHandlerError("No functions was provided");
-  //   }
 
   const assetsDir = join(targetDir, '.vercel/output/static');
   const assetsManifest = assetsPaths(assetsDir);

--- a/packages/presets/src/presets/next/node/prebuild/statics/index.js
+++ b/packages/presets/src/presets/next/node/prebuild/statics/index.js
@@ -108,7 +108,7 @@ function moduleTest(pathFile) {
  *      ],
  *      excludeDirs: ["./.next/cache"],
  *      out: "tmp-next-build",
- *      staticOutDir: ".edge/storage"
+ *      staticOutDir: ".edge/storage/next-build-assets"
  *   });
  *
  *   buildStatic.run();
@@ -121,14 +121,14 @@ class BuildStatic {
    * @param {string[]} config.includeDirs - directories for the build. e.g [".next"]
    * @param {string[]} config.excludeDirs - exclude directories. e.g [".next/cache"]
    * @param {string} config.out - directory where the file will be generated
-   * @param {string} config.staticOutDir - folder where statics are sent for upload default (.edge/storage)
+   * @param {string} config.staticOutDir - folder where statics are sent for upload default (.edge/storage/next-build-assets)
    * @param {Array<{ name: string, replace?: string | undefined }>} config.staticDirs - static directories.
    * @param {string} config.staticDirs.name - name static directory e.g './.next/static' | './public'.
    * @param {string | undefined} config.staticDirs.replace - this field is used to replace the original path e.g './.next/static' to './_next/static'.
    */
   constructor(config) {
     this.config = config;
-    this.config.staticOutDir = this.config.staticOutDir || '.edge/storage';
+    this.config.staticOutDir = this.config.staticOutDir || '.edge/storage/next-build-assets';
   }
 
   run = () => {

--- a/packages/presets/src/presets/nuxt/config.ts
+++ b/packages/presets/src/presets/nuxt/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: '.output/public',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/nuxt/prebuild.ts
+++ b/packages/presets/src/presets/nuxt/prebuild.ts
@@ -1,19 +1,23 @@
-import { copyDirectory, exec } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Nuxt
  */
-async function prebuild(): Promise<void> {
-  const newOutDir = '.edge/storage';
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const outDir = '.output/public';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec('npx nuxt generate', {
     scope: 'Nuxt',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/opennextjs/config.ts
+++ b/packages/presets/src/presets/opennextjs/config.ts
@@ -10,7 +10,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -27,8 +27,8 @@ const config: AzionConfig = {
   ],
   edgeFunctions: [
     {
-      name: 'handler',
-      path: '.edge/functions/handler.js',
+      name: '$EDGE_FUNCTION_NAME',
+      path: './functions/handler.js',
     },
   ],
   edgeApplications: [
@@ -116,6 +116,43 @@ const config: AzionConfig = {
           },
         ],
       },
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/opennextjs/prebuild.ts
+++ b/packages/presets/src/presets/opennextjs/prebuild.ts
@@ -6,7 +6,7 @@ import path from 'path';
 /**
  * Runs custom prebuild actions for OpenNextjs
  */
-async function prebuild(buildConfig: BuildConfiguration, ctx: BuildContext): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const pkgOpenNextjsName = '@aziontech/opennextjs-azion';
   const openNextjsCommand = 'npm exec opennextjs-azion';
 
@@ -33,11 +33,11 @@ async function prebuild(buildConfig: BuildConfiguration, ctx: BuildContext): Pro
     verbose: true,
     interactive: true,
   });
-  await exec(`${openNextjsCommand} populateAssets`, {
+  await exec(`${openNextjsCommand} populateAssets -- --cacheDir .edge/assets --assetsDir .edge/assets`, {
     scope: 'OpenNextjs',
     verbose: true,
   });
-  await exec(`${openNextjsCommand} populateCache`, {
+  await exec(`${openNextjsCommand} populateCache -- --cacheDir .edge/assets --assetsDir .edge/assets`, {
     scope: 'OpenNextjs',
     verbose: true,
   });

--- a/packages/presets/src/presets/preact/config.ts
+++ b/packages/presets/src/presets/preact/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createSPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/qwik/config.ts
+++ b/packages/presets/src/presets/qwik/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createSPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/qwik/prebuild.ts
+++ b/packages/presets/src/presets/qwik/prebuild.ts
@@ -1,13 +1,20 @@
+import { BuildConfiguration, BuildContext } from 'azion/config';
 import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
-import { readFile } from 'fs/promises';
+import { mkdir, readFile } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Qwik
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
+  const newOutDir = '.edge/assets';
   let outDir = 'dist';
+
+  // if skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(newOutDir, { recursive: true });
+    return;
+  }
 
   // Check if an output path is specified in config file
   try {
@@ -24,8 +31,7 @@ async function prebuild(): Promise<void> {
     scope: 'Qwik',
     verbose: true,
   });
-
-  // move files to vulcan default path
+  // move files to bundler default path
   copyDirectory(outDir, newOutDir);
 }
 

--- a/packages/presets/src/presets/react/config.ts
+++ b/packages/presets/src/presets/react/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createSPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/react/prebuild.ts
+++ b/packages/presets/src/presets/react/prebuild.ts
@@ -1,5 +1,6 @@
+import { BuildConfiguration, BuildContext } from 'azion/config';
 import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
-import { lstat, readFile } from 'fs/promises';
+import { lstat, mkdir, readFile } from 'fs/promises';
 import { join } from 'path';
 
 /**
@@ -50,11 +51,17 @@ async function readViteBuildOutput() {
 /**
  * Runs custom prebuild actions for React
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
+  // if skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir('.edge/assets', { recursive: true });
+    return;
+  }
+
   const packageManager = await getPackageManager();
   const npmArgsForward = packageManager === 'npm' ? '--' : '';
   const defaultViteOutDir = 'dist';
-  const destPath = '.edge/storage';
+  const destPath = '.edge/assets';
 
   const isViteProject = await viteConfigExists();
 

--- a/packages/presets/src/presets/rustwasm/config.ts
+++ b/packages/presets/src/presets/rustwasm/config.ts
@@ -36,7 +36,7 @@ const config: AzionConfig = {
   edgeFunctions: [
     {
       name: '$EDGE_FUNCTION_NAME',
-      path: '$LOCAL_FUNCTION_PATH',
+      path: './functions/handler.js',
     },
   ],
   edgeApplications: [
@@ -69,6 +69,43 @@ const config: AzionConfig = {
           },
         ],
       },
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/stencil/config.ts
+++ b/packages/presets/src/presets/stencil/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './www',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/stencil/prebuild.ts
+++ b/packages/presets/src/presets/stencil/prebuild.ts
@@ -1,20 +1,24 @@
-import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec, getPackageManager } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Stencil
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
   const outDir = 'www';
+
+  // if skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec(`${packageManager} run build`, {
     scope: 'Stencil',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/svelte/config.ts
+++ b/packages/presets/src/presets/svelte/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './build',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/svelte/prebuild.ts
+++ b/packages/presets/src/presets/svelte/prebuild.ts
@@ -1,20 +1,24 @@
-import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
+import { BuildConfiguration, BuildContext } from 'azion/config';
+import { exec, getPackageManager } from 'azion/utils/node';
+import { mkdir } from 'fs/promises';
 
 /**
  * Runs custom prebuild actions for Svelte
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
   const outDir = 'build';
+
+  // if skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(outDir, { recursive: true });
+    return;
+  }
 
   await exec(`${packageManager} run build`, {
     scope: 'Svelte',
     verbose: true,
   });
-
-  // move files to vulcan default path
-  copyDirectory(outDir, newOutDir);
 }
 
 export default prebuild;

--- a/packages/presets/src/presets/typescript/config.ts
+++ b/packages/presets/src/presets/typescript/config.ts
@@ -2,12 +2,12 @@ import type { AzionConfig } from 'azion/config';
 
 const config: AzionConfig = {
   build: {
-    entry: 'handler.ts',
+    entry: 'index.ts',
   },
   edgeFunctions: [
     {
       name: '$EDGE_FUNCTION_NAME',
-      path: '$LOCAL_FUNCTION_PATH',
+      path: './functions/index.js', // path to the edge function. This path is relative to the .edge folder.
     },
   ],
   edgeApplications: [
@@ -40,6 +40,43 @@ const config: AzionConfig = {
           },
         ],
       },
+      functionsInstances: [
+        {
+          name: '$EDGE_FUNCTION_INSTANCE_NAME',
+          ref: '$EDGE_FUNCTION_NAME',
+          args: {
+            environment: 'production',
+          },
+        },
+      ],
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/vitepress/config.ts
+++ b/packages/presets/src/presets/vitepress/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/vitepress/prebuild.ts
+++ b/packages/presets/src/presets/vitepress/prebuild.ts
@@ -1,5 +1,6 @@
+import { BuildConfiguration, BuildContext } from 'azion/config';
 import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
-import { lstat } from 'fs/promises';
+import { lstat, mkdir } from 'fs/promises';
 
 /**
  * Check if the project uses the "/docs"
@@ -16,13 +17,19 @@ async function docsFolderExists(): Promise<boolean> {
 /**
  * Runs custom prebuild actions for VitePress
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
-  const newOutDir = '.edge/storage';
+  const newOutDir = '.edge/assets';
 
   // The main folder for VitePress usually is 'docs',
   // however the users also might use the root folder
   const outDir = (await docsFolderExists()) ? 'docs/.vitepress/dist' : '.vitepress/dist';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(newOutDir, { recursive: true });
+    return;
+  }
 
   await exec(`${packageManager} run docs:build`, {
     scope: 'VitePress',

--- a/packages/presets/src/presets/vue/config.ts
+++ b/packages/presets/src/presets/vue/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createSPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };

--- a/packages/presets/src/presets/vue/prebuild.ts
+++ b/packages/presets/src/presets/vue/prebuild.ts
@@ -1,5 +1,6 @@
+import type { BuildConfiguration, BuildContext } from 'azion/config';
 import { copyDirectory, exec, getPackageManager } from 'azion/utils/node';
-import { lstat, readFile } from 'fs/promises';
+import { lstat, mkdir, readFile } from 'fs/promises';
 import { join } from 'path';
 
 /**
@@ -50,11 +51,17 @@ async function readViteBuildOutput() {
 /**
  * Runs custom prebuild actions for Vue
  */
-async function prebuild(): Promise<void> {
+async function prebuild(_: BuildConfiguration, ctx: BuildContext): Promise<void> {
   const packageManager = await getPackageManager();
   const npmArgsForward = packageManager === 'npm' ? '--' : '';
   const defaultViteOutDir = 'dist';
-  const destPath = '.edge/storage';
+  const destPath = '.edge/assets';
+
+  // If skipFrameworkBuild is true, we need to create the dist folder
+  if (ctx.skipFrameworkBuild) {
+    await mkdir(destPath, { recursive: true });
+    return;
+  }
 
   const isViteProject = await viteConfigExists();
 

--- a/packages/presets/src/presets/vuepress/config.ts
+++ b/packages/presets/src/presets/vuepress/config.ts
@@ -8,7 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
-      dir: '$LOCAL_BUCKET_DIR',
+      dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
   ],
@@ -29,6 +29,34 @@ const config: AzionConfig = {
       rules: createMPARules({
         edgeConnector: '$EDGE_CONNECTOR_NAME',
       }),
+    },
+  ],
+  workloads: [
+    {
+      name: '$WORKLOAD_NAME',
+      active: true,
+      infrastructure: 1,
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
+        {
+          name: '$DEPLOYMENT_NAME',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: '$EDGE_APPLICATION_NAME',
+            },
+          },
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Azion configuration processing and preset build workflows. The main themes are enhanced flexibility in workload domain requirements, improved preset build scripts to support skipping framework builds, and better default output directory handling for static site generators. Additionally, some configuration schemas and strategies have been updated for more robust and user-friendly behavior.

**Configuration Schema and Type Improvements**
- Made the `domains` field in `AzionWorkload` optional and defaulted to an empty array if not provided, relaxing the requirement for workloads to always specify domains. [[1]](diffhunk://#diff-bc8790029ada0b92644abb2c63a2cfeac3a0854eb92e1e66cd8bb6c9e9428189L817-R817) [[2]](diffhunk://#diff-1ad9cf065262277e6f4597159ef7411ac526cf9227c3e198dac95a878c99879eL55-R55) [[3]](diffhunk://#diff-3badacac288aefceb8f0de08abfc2b00288c97ea70859fe424844b7b7096f720L1066-R1066)
- Updated the `deployments` field in the workload schema to no longer require `domains`, aligning with the new optionality.

**Edge Application and Workload Strategy Fixes**
- Changed `edgeFunctionsEnabled` logic to enable edge functions if either explicitly enabled or if any function instances exist, providing more intuitive defaults. [[1]](diffhunk://#diff-e87e80b313322035bcdf04a7a074ab00fbff765c36279cc6b256e684ec4d5450L30-R31) [[2]](diffhunk://#diff-e87e80b313322035bcdf04a7a074ab00fbff765c36279cc6b256e684ec4d5450L85-R86)

**Preset Build Script Enhancements**
- Refactored all static site generator prebuild scripts (Angular, Astro, Docusaurus, Eleventy, Gatsby, Hexo) to accept a `BuildContext` and correctly handle the `skipFrameworkBuild` flag by creating the output directory if skipping the build, improving CI/CD and developer experience. [[1]](diffhunk://#diff-347b372a2e640f0f0b3797c1bf24b73c278111a83930bb58e7bbffcaf48c84caR1) [[2]](diffhunk://#diff-347b372a2e640f0f0b3797c1bf24b73c278111a83930bb58e7bbffcaf48c84caL24-R51) [[3]](diffhunk://#diff-26fedcb57b84974a3647f587690e37df360dc7395a660534b59277eecb69ae1fL1-R4) [[4]](diffhunk://#diff-26fedcb57b84974a3647f587690e37df360dc7395a660534b59277eecb69ae1fL29-L40) [[5]](diffhunk://#diff-d36fa992cb03c0579c5f639632a9e0357a4f0165157291fba9082175d1e977b6L1-L17) [[6]](diffhunk://#diff-35b4b6f8ace2ccb136f181ceedf9deb54d21f56fe63c2a9879c764d2b7c4be8eL1-L16) [[7]](diffhunk://#diff-c4dd253e0ea3edcd47641c6919cfe99429452ec32745580751a176cba9d8b266L1-L17) [[8]](diffhunk://#diff-8e08b1cce0db48ca44e4c189851b7d1694c1d6fb51ec03ccf14bedaf3c75f645L1-R17) [[9]](diffhunk://#diff-8e08b1cce0db48ca44e4c189851b7d1694c1d6fb51ec03ccf14bedaf3c75f645L24-L26)

**Preset Configuration Improvements**
- Standardized the default output directory for edge storage in all static site generator presets (Astro, Docusaurus, Eleventy, Gatsby, Hexo) to match each framework's build output, replacing placeholder values. [[1]](diffhunk://#diff-5b11fe0d4af0f030724d70fd651d981a302c730fc8dad6a555c08c4dc7d8d6d1L11-R11) [[2]](diffhunk://#diff-13a90e111f242f32a9055f95ca4d835c21151d11f0dfb0c7d8d1566be7fe1822L11-R11) [[3]](diffhunk://#diff-9f1354650d91bc1e4cba480d7c9c0acce40b9df7ff75d2d7046acad5c43af61bL11-R11) [[4]](diffhunk://#diff-3d8d7ae7ede6bd2ec9979da808823e0c9ac260337da1c73c6c899d9cb0b97966L11-R11)
- Added default `workloads` configuration blocks to Astro, Docusaurus, Eleventy, Gatsby, Hexo, and Emscripten presets for consistency and to provide out-of-the-box deployable examples. [[1]](diffhunk://#diff-5b11fe0d4af0f030724d70fd651d981a302c730fc8dad6a555c08c4dc7d8d6d1R34-R61) [[2]](diffhunk://#diff-13a90e111f242f32a9055f95ca4d835c21151d11f0dfb0c7d8d1566be7fe1822R34-R61) [[3]](diffhunk://#diff-9f1354650d91bc1e4cba480d7c9c0acce40b9df7ff75d2d7046acad5c43af61bR34-R61) [[4]](diffhunk://#diff-3d8d7ae7ede6bd2ec9979da808823e0c9ac260337da1c73c6c899d9cb0b97966R34-R61) [[5]](diffhunk://#diff-2b61e46cb6d104c6477c75726c7237b61e58c3ce1145ae8fd649ca4f1b61e75cR72-R108)

**Other Fixes and Cleanups**
- Updated the Emscripten preset to use a more conventional default function handler path and added function instances for clarity. [[1]](diffhunk://#diff-2b61e46cb6d104c6477c75726c7237b61e58c3ce1145ae8fd649ca4f1b61e75cL39-R39) [[2]](diffhunk://#diff-2b61e46cb6d104c6477c75726c7237b61e58c3ce1145ae8fd649ca4f1b61e75cR72-R108)
- Removed unnecessary `functionsInstances` and empty `domains` arrays from the Angular preset for cleaner configuration.

These changes collectively improve the developer experience, make configuration more robust and flexible, and ensure that the build and deployment process is more predictable and easier to customize.