### PR TITLE
fix: add storage prefix support across all presets and configurations

### DIFF
--- a/packages/bundler/src/polyfills/azion/fetch/context/fetch.context.js
+++ b/packages/bundler/src/polyfills/azion/fetch/context/fetch.context.js
@@ -21,16 +21,17 @@ function getUrlFromResource(context, resource) {
  * @param {URL|Request|string} resource - The resource to fetch.
  * @param {object} [options] - The fetch options.
  * @param {string} pathBucket - The path to the storage bucket.
+ * @param {string} prefixBucket - The prefix to the storage bucket.
  * @returns {Promise<Response>} A Promise that resolves to the Response object.
  */
-async function fetchContext(context, resource, options, pathBucket = '') {
+async function fetchContext(context, resource, options, pathBucket = '', prefixBucket = '') {
   const { Headers, Response, RESERVED_FETCH } = context;
 
   const urlObj = getUrlFromResource(context, resource);
 
   if (urlObj.href.startsWith('file://')) {
     const file = urlObj.pathname;
-    const filePath = join(process.cwd(), '.edge', 'storage', pathBucket, file);
+    const filePath = join(process.cwd(), '.edge', 'storage', pathBucket, prefixBucket, file);
 
     const fileContent = readFileSync(filePath);
     const contentType = mime.lookup(filePath) || 'application/octet-stream';

--- a/packages/config/src/configProcessor/helpers/azion.config.example.ts
+++ b/packages/config/src/configProcessor/helpers/azion.config.example.ts
@@ -410,6 +410,7 @@ const config: AzionConfig = {
       name: 'my-storage',
       edgeAccess: 'read_write', // 'read_only' | 'read_write' | 'restricted'
       dir: './storage',
+      prefix: '1236677364374',
     },
   ],
   purge: [

--- a/packages/config/src/configProcessor/helpers/schema.ts
+++ b/packages/config/src/configProcessor/helpers/schema.ts
@@ -452,8 +452,12 @@ const schemaStorage = {
       enum: EDGE_ACCESS_TYPES,
       errorMessage: "The 'edge_access' field must be one of: read_only, read_write, restricted.",
     },
+    prefix: {
+      type: 'string',
+      errorMessage: "The 'prefix' field must be a string.",
+    },
   },
-  required: ['name', 'dir'],
+  required: ['name', 'dir', 'prefix'],
   additionalProperties: false,
   errorMessage: {
     additionalProperties: 'No additional properties are allowed in storage items.',

--- a/packages/config/src/configProcessor/processStrategy/implementations/storageProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/storageProcessConfigStrategy.ts
@@ -16,6 +16,7 @@ class StorageProcessConfigStrategy extends ProcessConfigStrategy {
       name: item.name,
       edge_access: item.edgeAccess || 'read_only',
       dir: item.dir,
+      prefix: item.prefix,
     }));
   }
 
@@ -30,6 +31,7 @@ class StorageProcessConfigStrategy extends ProcessConfigStrategy {
       name: item.name,
       edgeAccess: item.edge_access || 'read_only',
       dir: item.dir,
+      prefix: item.prefix,
     }));
 
     return transformedPayload.edgeStorage;

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -524,6 +524,8 @@ export type AzionBucket = {
   edgeAccess?: 'read_only' | 'read_write' | 'restricted';
   /** Storage path */
   dir: string;
+  /** Storage prefix */
+  prefix: string;
 };
 
 /**

--- a/packages/presets/src/presets/angular/config.ts
+++ b/packages/presets/src/presets/angular/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './dist',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/astro/config.ts
+++ b/packages/presets/src/presets/astro/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './dist',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/docusaurus/config.ts
+++ b/packages/presets/src/presets/docusaurus/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './build',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/eleventy/config.ts
+++ b/packages/presets/src/presets/eleventy/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './_site',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/gatsby/config.ts
+++ b/packages/presets/src/presets/gatsby/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './public',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/hexo/config.ts
+++ b/packages/presets/src/presets/hexo/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './public',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/html/config.ts
+++ b/packages/presets/src/presets/html/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './www',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/hugo/config.ts
+++ b/packages/presets/src/presets/hugo/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './public',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/jekyll/config.ts
+++ b/packages/presets/src/presets/jekyll/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './_site',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/next/config.ts
+++ b/packages/presets/src/presets/next/config.ts
@@ -9,6 +9,7 @@ const config: AzionConfig = {
       name: '$BUCKET_NAME',
       dir: '.edge/next-build-assets',
       edgeAccess: 'read_only',
+      prefix: '$BUCKET_PREFIX',
     },
   ],
   edgeConnectors: [
@@ -26,6 +27,12 @@ const config: AzionConfig = {
     {
       name: '$EDGE_FUNCTION_NAME',
       path: './functions/handler.js',
+      bindings: {
+        storage: {
+          bucket: '$BUCKET_NAME',
+          prefix: '$BUCKET_PREFIX',
+        },
+      },
     },
   ],
   edgeApplications: [

--- a/packages/presets/src/presets/nuxt/config.ts
+++ b/packages/presets/src/presets/nuxt/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: '.output/public',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/opennextjs/config.ts
+++ b/packages/presets/src/presets/opennextjs/config.ts
@@ -10,6 +10,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },
@@ -28,7 +29,13 @@ const config: AzionConfig = {
   edgeFunctions: [
     {
       name: '$EDGE_FUNCTION_NAME',
-      path: './functions/handler.js',
+      path: './functions/worker.js',
+      bindings: {
+        storage: {
+          bucket: '$BUCKET_NAME',
+          prefix: '$BUCKET_PREFIX',
+        },
+      },
     },
   ],
   edgeApplications: [
@@ -106,7 +113,7 @@ const config: AzionConfig = {
               {
                 type: 'run_function',
                 attributes: {
-                  value: 'handler',
+                  value: '$EDGE_FUNCTION_NAME',
                 },
               },
               {

--- a/packages/presets/src/presets/preact/config.ts
+++ b/packages/presets/src/presets/preact/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/qwik/config.ts
+++ b/packages/presets/src/presets/qwik/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/react/config.ts
+++ b/packages/presets/src/presets/react/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/stencil/config.ts
+++ b/packages/presets/src/presets/stencil/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './www',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/svelte/config.ts
+++ b/packages/presets/src/presets/svelte/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './build',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/vitepress/config.ts
+++ b/packages/presets/src/presets/vitepress/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/vue/config.ts
+++ b/packages/presets/src/presets/vue/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },

--- a/packages/presets/src/presets/vuepress/config.ts
+++ b/packages/presets/src/presets/vuepress/config.ts
@@ -8,6 +8,7 @@ const config: AzionConfig = {
   edgeStorage: [
     {
       name: '$BUCKET_NAME',
+      prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
       edgeAccess: 'read_only',
     },


### PR DESCRIPTION
This pull request introduces support for a required storage bucket prefix across the configuration system, presets, and fetch context logic. The main focus is to ensure that every storage bucket configuration includes a `prefix` property, and that this prefix is properly handled throughout the codebase, including when accessing files and generating preset configs.

**Configuration schema and type updates:**

- Made the `prefix` property required for all storage bucket configurations in the schema (`schema.ts`), and updated error messages accordingly. (`[packages/config/src/configProcessor/helpers/schema.tsR455-R460](diffhunk://#diff-3badacac288aefceb8f0de08abfc2b00288c97ea70859fe424844b7b7096f720R455-R460)`)
- Updated the `AzionBucket` type to include a required `prefix` field. (`[packages/config/src/types.tsR527-R528](diffhunk://#diff-bc8790029ada0b92644abb2c63a2cfeac3a0854eb92e1e66cd8bb6c9e9428189R527-R528)`)

**Configuration processing logic:**

- Modified `StorageProcessConfigStrategy` to handle the new `prefix` property during both serialization and deserialization of storage config items. (`[[1]](diffhunk://#diff-db9e58500a8fe9c58ccc3944e723031cd3db0885ffb2084edf578d2d74397e91R19)`, `[[2]](diffhunk://#diff-db9e58500a8fe9c58ccc3944e723031cd3db0885ffb2084edf578d2d74397e91R34)`)

**Preset configuration updates:**

- Updated all framework preset configuration files (Angular, Astro, Docusaurus, Eleventy, Gatsby, Hexo, Hugo, HTML, Jekyll, Next.js, Nuxt, OpenNextJS, Preact, Qwik, React) to include the `prefix` field in their `edgeStorage` definitions, using a placeholder value. (`[[1]](diffhunk://#diff-0b08b39abf37c25eb06b6ad389c4c159dda7a8f9d6b56c34983fe57f0abbba1fR11)`, `[[2]](diffhunk://#diff-5b11fe0d4af0f030724d70fd651d981a302c730fc8dad6a555c08c4dc7d8d6d1R11)`, `[[3]](diffhunk://#diff-13a90e111f242f32a9055f95ca4d835c21151d11f0dfb0c7d8d1566be7fe1822R11)`, `[[4]](diffhunk://#diff-9f1354650d91bc1e4cba480d7c9c0acce40b9df7ff75d2d7046acad5c43af61bR11)`, `[[5]](diffhunk://#diff-3d8d7ae7ede6bd2ec9979da808823e0c9ac260337da1c73c6c899d9cb0b97966R11)`, `[[6]](diffhunk://#diff-7460aed51e9e666c2a9dde62226bcea14b55c8a8f63e73eb851d6b21a6e7cd65R11)`, `[[7]](diffhunk://#diff-9bca01b8df43c7391e80b36fc793fe49aeb9ac072dfa6ef9b0f27ae3016f5dc3R12)`, `[[8]](diffhunk://#diff-5fcbdeef49033d7f92de61fce0c74ad5e8f6808d2e82cbea1f05025ed0e89c08R11)`, `[[9]](diffhunk://#diff-90072cbf2072d6d2e7eedeb14035d60ddee13e681d000ace286415dcab5d9d17R13)`, `[[10]](diffhunk://#diff-5e706584220328d989440d8c85a71cb25bd831cdce076abac420642b66531969R11)`)
- Updated Next.js and OpenNextJS presets to include the `prefix` in edge function bindings and to reference the correct function name in application routes. (`[[1]](diffhunk://#diff-9bca01b8df43c7391e80b36fc793fe49aeb9ac072dfa6ef9b0f27ae3016f5dc3R30-R35)`, `[[2]](diffhunk://#diff-90072cbf2072d6d2e7eedeb14035d60ddee13e681d000ace286415dcab5d9d17L31-R38)`, `[[3]](diffhunk://#diff-90072cbf2072d6d2e7eedeb14035d60ddee13e681d000ace286415dcab5d9d17L109-R116)`)

**Fetch context logic:**

- Updated `fetchContext` to accept a `prefixBucket` argument and use it when resolving file paths for file-based URLs, ensuring files are accessed with the correct prefix. (`[packages/bundler/src/polyfills/azion/fetch/context/fetch.context.jsR24-R34](diffhunk://#diff-ee05e463faa727451143e9c4c1c00bce700c51f6ea026381de1fd4191306d660R24-R34)`)

**Example configuration update:**

- Added a `prefix` example to the Azion config example file. (`[packages/config/src/configProcessor/helpers/azion.config.example.tsR413](diffhunk://#diff-bfed22d7a164b042c037f78705e7b81d33e46dfce8ea6d172fad865dd0a7dc1cR413)`)