### PR TITLE
fix: require prefix field in storage bindings and update error messages

### DIFF
--- a/packages/config/src/configProcessor/helpers/schema.ts
+++ b/packages/config/src/configProcessor/helpers/schema.ts
@@ -413,12 +413,12 @@ const schemaFunction = {
               errorMessage: "The 'prefix' field must be a string",
             },
           },
-          required: ['bucket'],
+          required: ['bucket', 'prefix'],
           additionalProperties: false,
           errorMessage: {
             type: "The 'storage' field must be an object",
-            additionalProperties: 'No additional properties are allowed in the storage object',
-            required: "The 'bucket' field is required in the storage object",
+            additionalProperties: 'No additional properties are allowed in the storage object binding.',
+            required: "The 'bucket' and 'prefix' fields are required in the storage object binding.",
           },
         },
       },
@@ -461,7 +461,7 @@ const schemaStorage = {
   additionalProperties: false,
   errorMessage: {
     additionalProperties: 'No additional properties are allowed in storage items.',
-    required: "The 'name' and 'dir' fields are required.",
+    required: "The 'name', 'dir' and 'prefix' fields are required.",
   },
 };
 
@@ -1517,9 +1517,9 @@ const azionConfigSchema = {
                         errorMessage: "The 'prefix' field must be a string between 0 and 255 characters",
                       },
                     },
-                    required: ['bucket'],
+                    required: ['bucket', 'prefix'],
                     additionalProperties: false,
-                    errorMessage: 'Edge storage attributes must have bucket and optional prefix',
+                    errorMessage: 'Edge storage attributes must have bucket and prefix',
                   },
                   {
                     type: 'object',


### PR DESCRIPTION
This pull request updates the schema validation logic in `schema.ts` to require the `prefix` field in several storage-related configuration objects. The error messages have also been revised to clearly indicate that both `bucket` and `prefix` are required fields.

Schema validation updates:

* The `storage` object in `schemaFunction` now requires both the `bucket` and `prefix` fields, and the error message reflects this requirement.
* The `storage` items in `schemaStorage` now require the `name`, `dir`, and `prefix` fields, with an updated error message.
* The `azionConfigSchema` now requires both `bucket` and `prefix` for edge storage attributes, and the error message has been updated accordingly.