### PR TITLE
fix: adjustments to generate manifest and presets

### DIFF
--- a/packages/config/src/configProcessor/processStrategy/implementations/application/edgeApplicationProcessConfigStrategy.ts
+++ b/packages/config/src/configProcessor/processStrategy/implementations/application/edgeApplicationProcessConfigStrategy.ts
@@ -31,7 +31,7 @@ class EdgeApplicationProcessConfigStrategy extends ProcessConfigStrategy {
               app.edgeFunctionsEnabled || (app.functionsInstances && app.functionsInstances.length > 0) ? true : false,
           },
           application_accelerator: {
-            enabled: app.applicationAcceleratorEnabled ?? false,
+            enabled: app.applicationAcceleratorEnabled ?? true,
           },
           image_processor: {
             enabled: app.imageProcessorEnabled ?? false,

--- a/packages/presets/src/presets/opennextjs/config.ts
+++ b/packages/presets/src/presets/opennextjs/config.ts
@@ -12,7 +12,7 @@ const config: AzionConfig = {
       name: '$BUCKET_NAME',
       prefix: '$BUCKET_PREFIX',
       dir: './.edge/assets',
-      edgeAccess: 'read_only',
+      edgeAccess: 'read_write',
     },
   ],
   edgeConnectors: [


### PR DESCRIPTION
This pull request introduces two key configuration changes aimed at enabling more features by default and expanding access permissions for asset storage. These updates impact both application process configuration and asset storage presets.

Configuration changes:

* Updated the `application_accelerator` feature in `edgeApplicationProcessConfigStrategy.ts` to be enabled by default unless explicitly disabled, by changing the fallback value to `true`.
* Changed the `edgeAccess` permission for asset storage in the OpenNext.js preset configuration from `'read_only'` to `'read_write'`, allowing both read and write operations on assets at the edge.