### PR TITLE
refactor: remove hardcoded production environment from edge function instances

### DIFF
--- a/packages/presets/src/presets/emscripten/config.ts
+++ b/packages/presets/src/presets/emscripten/config.ts
@@ -73,9 +73,6 @@ const config: AzionConfig = {
         {
           name: '$EDGE_FUNCTION_INSTANCE_NAME',
           ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
         },
       ],
     },

--- a/packages/presets/src/presets/javascript/config.ts
+++ b/packages/presets/src/presets/javascript/config.ts
@@ -44,9 +44,6 @@ const config: AzionConfig = {
         {
           name: '$EDGE_FUNCTION_INSTANCE_NAME',
           ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
         },
       ],
     },

--- a/packages/presets/src/presets/next/config.ts
+++ b/packages/presets/src/presets/next/config.ts
@@ -124,9 +124,6 @@ const config: AzionConfig = {
         {
           name: '$EDGE_FUNCTION_INSTANCE_NAME',
           ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
         },
       ],
     },

--- a/packages/presets/src/presets/opennextjs/config.ts
+++ b/packages/presets/src/presets/opennextjs/config.ts
@@ -127,9 +127,6 @@ const config: AzionConfig = {
         {
           name: '$EDGE_FUNCTION_INSTANCE_NAME',
           ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
         },
       ],
     },

--- a/packages/presets/src/presets/rustwasm/config.ts
+++ b/packages/presets/src/presets/rustwasm/config.ts
@@ -73,9 +73,6 @@ const config: AzionConfig = {
         {
           name: '$EDGE_FUNCTION_INSTANCE_NAME',
           ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
         },
       ],
     },

--- a/packages/presets/src/presets/typescript/config.ts
+++ b/packages/presets/src/presets/typescript/config.ts
@@ -44,9 +44,6 @@ const config: AzionConfig = {
         {
           name: '$EDGE_FUNCTION_INSTANCE_NAME',
           ref: '$EDGE_FUNCTION_NAME',
-          args: {
-            environment: 'production',
-          },
         },
       ],
     },


### PR DESCRIPTION
This pull request removes the explicit `args: { environment: 'production' }` configuration from the `$EDGE_FUNCTION_INSTANCE_NAME` resource in several preset configuration files. This change likely simplifies the deployment configuration and relies on defaults or alternative mechanisms for setting the environment.

Configuration simplification across presets:

* Removed the `args: { environment: 'production' }` property from the `$EDGE_FUNCTION_INSTANCE_NAME` resource in the following preset config files:
  * `emscripten/config.ts`
  * `javascript/config.ts`
  * `next/config.ts`
  * `opennextjs/config.ts`
  * `rustwasm/config.ts`
  * `typescript/config.ts`