### PR TITLE
docs!: restructure configuration API to workloads-based architecture

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,6 +1,6 @@
-# Azion Edge Application Configuration
+# Azion Edge Platform Configuration
 
-This module provides a function to configure and validate options for the Azion Edge Application. It supports various configurations, including domain settings, origin settings, cache settings, rules, network lists, and purge operations.
+This module provides comprehensive configuration and validation for the Azion Edge Platform. It supports edge applications, workloads, edge connectors, edge functions, storage, firewall rules, WAF settings, network lists, custom pages, and purge operations.
 
 ## Table of Contents
 
@@ -16,16 +16,18 @@ This module provides a function to configure and validate options for the Azion 
 - [Types](#types)
   - [`AzionBuild`](#azionbuild)
   - [`AzionConfig`](#azionconfig)
-  - [`AzionDomain`](#aziondomain)
-  - [`AzionOrigin`](#azionorigin)
+  - [`AzionEdgeApplication`](#azionedgeapplication)
+  - [`AzionWorkload`](#azionworkload)
+  - [`AzionEdgeConnector`](#azionedgeconnector)
+  - [`AzionEdgeFunction`](#azionedgefunction)
+  - [`AzionEdgeStorage`](#azionedgestorage)
   - [`AzionCache`](#azioncache)
-  - [`AzionRuntimeRequestRule`](#AzionRuntimeRequestrule)
-  - [`AzionResponseRule`](#azionresponserule)
   - [`AzionRules`](#azionrules)
   - [`AzionPurge`](#azionpurge)
   - [`AzionNetworkList`](#azionnetworklist)
-  - [`AzionFirewall`](#azionfirewall)
+  - [`AzionEdgeFirewall`](#azionedgefirewall)
   - [`AzionWaf`](#azionwaf)
+  - [`AzionCustomPages`](#azioncustompages)
 
 ## Installation
 
@@ -62,126 +64,297 @@ export default config;
 import { defineConfig } from 'azion/config';
 
 const config = defineConfig({
-  domain: {
-    name: 'example.com',
-    cnameAccessOnly: false,
-    cnames: ['www.example.com', 'cdn.example.com'],
-    Id: 12345,
-    edgeFirewallId: 67890,
-    digitalCertificateId: null,
-    mtls: {
-      verification: 'enforce',
-      trustedCaCertificateId: 98765,
-    },
+  build: {
+    entry: './src/index.js',
+    preset: 'angular', // 'angular' | 'react' | 'next' | 'vue' | 'nuxt' | 'astro' | etc.
+    bundler: 'webpack', // 'webpack' | 'esbuild'
   },
-  origin: [
+  edgeApplications: [
     {
-      name: 'My Origin',
-      type: 'single_origin',
-      addresses: [
+      name: 'my-edge-app',
+      active: true,
+      debug: false,
+      edgeCacheEnabled: true,
+      edgeFunctionsEnabled: false,
+      applicationAcceleratorEnabled: false,
+      imageProcessorEnabled: false,
+      tieredCacheEnabled: false,
+      cache: [
         {
-          address: 'origin.example.com',
-          weight: 100,
+          name: 'mycache',
+          stale: false,
+          queryStringSort: false,
+          methods: {
+            post: false,
+            options: false,
+          },
+          browser: {
+            maxAgeSeconds: 5000,
+          },
+          edge: {
+            maxAgeSeconds: 1000,
+          },
+          cacheByQueryString: {
+            option: 'denylist',
+            list: ['order', 'user'],
+          },
+          cacheByCookie: {
+            option: 'allowlist',
+            list: ['session', 'user'],
+          },
         },
       ],
-      protocolPolicy: 'https',
+      rules: {
+        request: [
+          {
+            name: 'rewriteRuleExample',
+            description: 'Rewrite URLs, set cookies and headers, forward cookies.',
+            active: true,
+            criteria: [
+              [
+                {
+                  variable: '${uri}',
+                  conditional: 'if',
+                  operator: 'matches',
+                  argument: '^/rewrite$',
+                },
+              ],
+            ],
+            behaviors: [
+              {
+                type: 'set_cache_policy',
+                attributes: {
+                  value: 'mycache',
+                },
+              },
+              {
+                type: 'rewrite_request',
+                attributes: {
+                  value: '/new/%{captured[1]}',
+                },
+              },
+            ],
+          },
+        ],
+        response: [
+          {
+            name: 'apiDataResponseRuleExample',
+            description: 'Manage headers, cookies, and GZIP compression.',
+            active: true,
+            criteria: [
+              [
+                {
+                  variable: '${uri}',
+                  conditional: 'if',
+                  operator: 'matches',
+                  argument: '^/api/data',
+                },
+              ],
+            ],
+            behaviors: [
+              {
+                type: 'add_response_header',
+                attributes: {
+                  value: 'Content-Type: application/json',
+                },
+              },
+              {
+                type: 'enable_gzip',
+              },
+            ],
+          },
+        ],
+      },
+      functionsInstances: [
+        {
+          name: 'auth-function-instance',
+          ref: 'my-edge-function',
+          args: {
+            environment: 'production',
+            apiUrl: 'https://api.example.com',
+          },
+        },
+      ],
     },
   ],
-  cache: [
+  edgeConnectors: [
     {
-      name: 'Default Cache',
-      browser: {
-        maxAgeSeconds: 3600,
-      },
-      edge: {
-        maxAgeSeconds: 7200,
+      name: 'my-http-connector',
+      active: true,
+      type: 'http',
+      attributes: {
+        addresses: [
+          {
+            active: true,
+            address: 'api.example.com',
+            httpPort: 80,
+            httpsPort: 443,
+          },
+        ],
+        connectionOptions: {
+          dnsResolution: 'preserve',
+          transportPolicy: 'preserve',
+          httpVersionPolicy: 'http1_1',
+          host: '${host}',
+          pathPrefix: '',
+          followingRedirect: false,
+        },
+        modules: {
+          loadBalancer: {
+            enabled: false,
+            config: null,
+          },
+          originShield: {
+            enabled: false,
+            config: null,
+          },
+        },
       },
     },
   ],
-  rules: {
-    request: [
-      {
-        name: 'Example Rule',
-        match: 'path',
-        behavior: {
-          setOrigin: {
-            name: 'My Origin',
-            type: 'single_origin',
-          },
+  edgeFunctions: [
+    {
+      name: 'my-edge-function',
+      path: './functions/index.js',
+      runtime: 'azion_js',
+      defaultArgs: {
+        defaultEnv: 'development',
+      },
+      executionEnvironment: 'application',
+      active: true,
+      bindings: {
+        storage: {
+          bucket: 'my-storage',
+          prefix: 'auth-data/',
         },
       },
-    ],
-  },
-  firewall: {
-    name: 'My Edge Firewall',
-    domains: ['example.com', 'api.example.com'],
-    active: true,
-    edgeFunctions: true,
-    networkProtection: true,
-    waf: true,
-    rules: [
-      {
-        name: 'Block Suspicious IPs',
-        description: 'Block requests from suspicious IP addresses',
-        active: true,
-        criteria: [
-          {
-            variable: '${remote_addr}',
-            operator: 'in',
-            conditional: 'if',
-            inputValue: 'suspicious_ips',
-          },
-        ],
-        behavior: {
-          deny: true,
+    },
+  ],
+  edgeStorage: [
+    {
+      name: 'my-storage',
+      edgeAccess: 'read_write',
+      dir: './storage',
+      prefix: '1236677364374',
+    },
+  ],
+  workloads: [
+    {
+      name: 'my-production-workload',
+      active: true,
+      infrastructure: 1,
+      domains: ['example.com', 'www.example.com'],
+      workloadDomainAllowAccess: true,
+      tls: {
+        certificate: 12345,
+        ciphers: 1,
+        minimumVersion: 'tls_1_3',
+      },
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
         },
       },
-      {
-        name: 'Rate Limit API',
-        description: 'Rate limit for API endpoints',
-        active: true,
-        criteria: [
-          {
-            variable: '${uri}',
-            operator: 'starts_with',
-            conditional: 'if',
-            inputValue: '/api/',
-          },
-        ],
-        behavior: {
-          setRateLimit: {
-            type: 'second',
-            limitBy: 'client_ip',
-            averageRateLimit: '10',
-            maximumBurstSize: '20',
+      mtls: {
+        verification: 'enforce',
+        certificate: 67890,
+        crl: [1, 2, 3],
+      },
+      deployments: [
+        {
+          name: 'production-deployment',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: 'my-edge-app',
+              edgeFirewall: 'my-edge-firewall',
+              customPage: 'my-custom-error-pages',
+            },
           },
         },
+      ],
+    },
+  ],
+  edgeFirewall: [
+    {
+      name: 'my_edge_firewall',
+      domains: ['www.example.com', 'api.example.com'],
+      active: true,
+      edgeFunctions: true,
+      networkProtection: true,
+      waf: true,
+      rules: [
+        {
+          name: 'rateLimit_Then_Drop',
+          active: true,
+          match: '^/api/sensitive/',
+          behavior: {
+            setRateLimit: {
+              type: 'second',
+              limitBy: 'clientIp',
+              averageRateLimit: '10',
+              maximumBurstSize: '20',
+            },
+          },
+        },
+      ],
+    },
+  ],
+  networkList: [
+    {
+      name: 'my-ip-allowlist',
+      type: 'ip_cidr',
+      items: ['10.0.0.1/32', '192.168.1.0/24'],
+      active: true,
+    },
+  ],
+  waf: [
+    {
+      name: 'my-waf-v4',
+      productVersion: '1.0',
+      engineSettings: {
+        engineVersion: '2021-Q3',
+        type: 'score',
+        attributes: {
+          rulesets: [1],
+          thresholds: [
+            { threat: 'sql_injection', sensitivity: 'high' },
+            { threat: 'cross_site_scripting', sensitivity: 'high' },
+          ],
+        },
       },
-    ],
-  },
+    },
+  ],
+  customPages: [
+    {
+      name: 'my-custom-error-pages',
+      active: true,
+      pages: [
+        {
+          code: '404',
+          page: {
+            type: 'page_connector',
+            attributes: {
+              connector: 'my-edge-connector',
+              ttl: 3600,
+              uri: '/errors/404.html',
+              customStatusCode: 404,
+            },
+          },
+        },
+      ],
+    },
+  ],
   purge: [
     {
       type: 'url',
-      urls: ['https://example.com/path/to/purge'],
-      method: 'delete',
-      layer: 'edge_caching',
-    },
-  ],
-  networkLists: [
-    {
-      id: 12345,
-      listType: 'ip_cidr',
-      listContent: ['10.0.0.1'],
-    },
-    {
-      id: 67890,
-      listType: 'asn',
-      listContent: [12345],
-    },
-    {
-      id: 98765,
-      listType: 'countries',
-      listContent: ['US', 'CA'],
+      items: ['http://www.example.com/image.jpg'],
+      layer: 'edge_cache',
     },
   ],
 });
@@ -215,17 +388,39 @@ console.log(manifest);
 import { convertJsonConfigToObject } from 'azion';
 
 const manifestJson = {
-  origin: [
+  workloads: [
     {
-      name: 'My Origin',
-      origin_type: 'single_origin',
-      addresses: [
+      name: 'my-production-workload',
+      active: true,
+      infrastructure: 1,
+      domains: ['example.com', 'www.example.com'],
+      workloadDomainAllowAccess: true,
+      tls: {
+        certificate: 12345,
+        ciphers: 1,
+        minimumVersion: 'tls_1_3',
+      },
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
         {
-          address: 'origin.example.com',
-          weight: 100,
+          name: 'production-deployment',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: 'my-edge-app',
+            },
+          },
         },
       ],
-      origin_protocol_policy: 'https',
     },
   ],
 };
@@ -239,17 +434,39 @@ console.log(manifest);
 import { AzionConfig, convertJsonConfigToObject } from 'azion';
 
 const manifestJson = {
-  origin: [
+  workloads: [
     {
-      name: 'My Origin',
-      origin_type: 'single_origin',
-      addresses: [
+      name: 'my-production-workload',
+      active: true,
+      infrastructure: 1,
+      domains: ['example.com', 'www.example.com'],
+      workloadDomainAllowAccess: true,
+      tls: {
+        certificate: 12345,
+        ciphers: 1,
+        minimumVersion: 'tls_1_3',
+      },
+      protocols: {
+        http: {
+          versions: ['http1', 'http2'],
+          httpPorts: [80],
+          httpsPorts: [443],
+          quicPorts: null,
+        },
+      },
+      deployments: [
         {
-          address: 'origin.example.com',
-          weight: 100,
+          name: 'production-deployment',
+          current: true,
+          active: true,
+          strategy: {
+            type: 'default',
+            attributes: {
+              edgeApplication: 'my-edge-app',
+            },
+          },
         },
       ],
-      origin_protocol_policy: 'https',
     },
   ],
 };
@@ -292,13 +509,16 @@ Converts a Azion JSON configuration object to a AzionConfig object.
 **Properties:**
 
 - `build?: AzionBuild` - The build configuration.
-- `domain?: AzionDomain` - The domain object.
-- `origin?: AzionOrigin[]` - List of origins.
-- `cache?: AzionCache[]` - List of cache settings.
-- `rules?: AzionRules[]` - List of edge rules.
-- `purge?: AzionPurge[]` - List of URLs or CacheKeys to purge.
-- `networkLists?: AzionNetworkList[]` - List of network lists.
+- `edgeApplications?: AzionEdgeApplication[]` - List of edge applications.
+- `workloads?: AzionWorkload[]` - List of workloads for domain management.
+- `edgeConnectors?: AzionEdgeConnector[]` - List of edge connectors (HTTP, storage, live ingest).
+- `edgeFunctions?: AzionEdgeFunction[]` - List of edge functions.
+- `edgeStorage?: AzionEdgeStorage[]` - List of edge storage configurations.
+- `purge?: AzionPurge[]` - List of URLs or cache keys to purge.
+- `networkList?: AzionNetworkList[]` - List of network lists.
+- `edgeFirewall?: AzionEdgeFirewall[]` - List of edge firewall configurations.
 - `waf?: AzionWaf[]` - List of WAF configurations.
+- `customPages?: AzionCustomPages[]` - List of custom error page configurations.
 
 ### `AzionBuild`
 
@@ -392,46 +612,94 @@ Type definition for the preset metadata.
 - `registry?: string` - Preset registry.
 - `ext?: string` - File extension.
 
-### `AzionDomain`
+### `AzionEdgeApplication`
 
-Type definition for the domain configuration.
+Type definition for edge application configuration.
 
 **Properties:**
 
-- `name: string` - The domain name.
-- `cnameAccessOnly?: boolean` - Whether to restrict access only to CNAMEs.
-- `cnames?: string[]` - List of CNAMEs for the domain.
-- `id?: number` - ID of the edge application.
-- `edgeApplicationId?: number` - ID of the edge application.
-- `edgeFirewallId?: number` - ID of the edge firewall.
-- `digitalCertificateId?: string | number | null` - ID of the digital certificate.
-- `active?: boolean` - Whether the domain is active.
-- `mtls?: MTLSConfig` - Configuration for mTLS.
+- `name: string` - Name of the edge application (1-250 characters).
+- `active?: boolean` - Whether the application is active (default: true).
+- `debug?: boolean` - Whether debug mode is enabled (default: false).
+- `edgeCacheEnabled?: boolean` - Whether edge cache is enabled (default: true).
+- `edgeFunctionsEnabled?: boolean` - Whether edge functions are enabled (default: false).
+- `applicationAcceleratorEnabled?: boolean` - Whether application accelerator is enabled (default: false).
+- `imageProcessorEnabled?: boolean` - Whether image processor is enabled (default: false).
+- `tieredCacheEnabled?: boolean` - Whether tiered cache is enabled (default: false).
+- `cache?: AzionCache[]` - List of cache configurations.
+- `rules?: AzionRules` - Request and response rules.
+- `deviceGroups?: DeviceGroup[]` - List of device groups for mobile detection.
+- `functionsInstances?: FunctionInstance[]` - List of function instances.
+
+### `AzionWorkload`
+
+Type definition for workload configuration (domain management).
+
+**Properties:**
+
+- `name: string` - Name of the workload (1-100 characters).
+- `active?: boolean` - Whether the workload is active (default: true).
+- `infrastructure?: 1 | 2` - Infrastructure type (1 for production, 2 for development).
+- `workloadDomainAllowAccess?: boolean` - Whether to allow domain access (default: true).
+- `domains: string[]` - List of domains (1-250 characters each).
+- `tls?: TLSConfig` - TLS configuration.
+  - `certificate?: number | null` - Certificate ID.
+  - `ciphers?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | null` - TLS cipher suite.
+  - `minimumVersion?: 'tls_1_0' | 'tls_1_1' | 'tls_1_2' | 'tls_1_3' | null` - Minimum TLS version.
+- `protocols?: ProtocolConfig` - Protocol configuration.
+  - `http: { versions: string[], httpPorts: number[], httpsPorts: number[], quicPorts?: number[] | null }`
+- `mtls?: MTLSConfig` - Mutual TLS configuration.
   - `verification: 'enforce' | 'permissive'` - mTLS verification mode.
-  - `trustedCaCertificateId: number` - ID of the trusted CA certificate.
-  - `crlList?: number[]` - List of Certificate Revocation Lists (CRLs).
+  - `certificate?: number | null` - Certificate ID.
+  - `crl?: number[] | null` - Certificate Revocation Lists.
+- `deployments: Deployment[]` - List of deployments.
 
-### `AzionOrigin`
+### `AzionEdgeConnector`
 
-Type definition for the origin configuration.
+Type definition for edge connector configuration.
 
 **Properties:**
 
-- `id?: number` - ID of the origin.
-- `key?: string` - Key for the origin.
-- `name: string` - Name of the origin.
-- `type: string` - Type of the origin (e.g., 'single_origin', 'load_balancer').
-- `bucket?: string | null` - Bucket name for storage origins.
-- `prefix?: string | null` - Prefix for storage origins.
-- `addresses?: (string | { address: string; weight?: number })[]` - Array of addresses for the origin.
-- `hostHeader?: string` - Custom host header.
-- `protocolPolicy?: 'http' | 'https' | 'preserve'` - Protocol policy for the origin.
-- `redirection?: boolean` - Whether to enable redirection.
-- `method?: 'ip_hash' | 'least_connections' | 'round_robin'` - Load balancing method.
-- `path?: string` - Path for the origin.
-- `connectionTimeout?: number` - Connection timeout in seconds.
-- `timeoutBetweenBytes?: number` - Timeout between bytes in seconds.
-- `hmac?: { region: string; accessKey: string; secretKey: string }` - HMAC configuration for the origin.
+- `name: string` - Name of the edge connector (1-255 characters).
+- `active?: boolean` - Whether the connector is active (default: true).
+- `type: 'http' | 'edge_storage' | 'live_ingest'` - Type of edge connector.
+- `attributes: EdgeConnectorAttributes` - Connector-specific attributes.
+
+**For HTTP/Live Ingest connectors:**
+
+- `addresses: Address[]` - List of backend addresses.
+- `connectionOptions: ConnectionOptions` - Connection configuration.
+- `modules: ConnectorModules` - Load balancer and origin shield modules.
+
+**For Edge Storage connectors:**
+
+- `bucket: string` - Storage bucket name.
+- `prefix: string` - Storage prefix path.
+
+### `AzionEdgeFunction`
+
+Type definition for edge function configuration.
+
+**Properties:**
+
+- `name: string` - Name of the edge function (1-250 characters).
+- `path: string` - Path to the function file.
+- `runtime?: 'azion_js'` - Runtime environment (default: 'azion_js').
+- `defaultArgs?: object` - Default arguments for the function (default: {}).
+- `executionEnvironment?: 'application' | 'firewall'` - Execution environment (default: 'application').
+- `active?: boolean` - Whether the function is active (default: true).
+- `bindings?: FunctionBindings` - Function bindings (e.g., storage).
+
+### `AzionEdgeStorage`
+
+Type definition for edge storage configuration.
+
+**Properties:**
+
+- `name: string` - Name of the storage (6-63 characters).
+- `dir: string` - Local directory path.
+- `edgeAccess?: 'read_only' | 'read_write' | 'restricted'` - Edge access permissions.
+- `prefix: string` - Storage prefix.
 
 ### `AzionCache`
 
@@ -439,188 +707,191 @@ Type definition for the cache configuration.
 
 **Properties:**
 
-- `name: string` - Name of the cache configuration.
+- `name: string` - Name of the cache configuration (1-250 characters, pattern: `^[a-zA-Z0-9 \\-.',|]+$`).
 - `stale?: boolean` - Whether to allow stale content.
 - `queryStringSort?: boolean` - Whether to sort query string parameters.
 - `methods?: CacheMethods` - HTTP methods to cache.
   - `post?: boolean` - Whether to cache POST requests.
   - `options?: boolean` - Whether to cache OPTIONS requests.
 - `browser?: BrowserCacheConfig` - Browser cache settings.
-  - `maxAgeSeconds: number | string` - Maximum age for browser cache in seconds.
+  - `maxAgeSeconds: number | string` - Maximum age for browser cache in seconds (supports mathematical expressions).
 - `edge?: EdgeCacheConfig` - Edge cache settings.
-  - `maxAgeSeconds: number | string` - Maximum age for edge cache in seconds.
+  - `maxAgeSeconds: number | string` - Maximum age for edge cache in seconds (supports mathematical expressions).
 - `cacheByCookie?: CacheByCookieConfig` - Cache by cookie settings.
-  - `option: 'ignore' | 'varies' | 'whitelist' | 'blacklist'` - Cache by cookie option.
-  - `list?: string[]` - List of cookies to use for caching.
+  - `option: 'ignore' | 'all' | 'allowlist' | 'denylist'` - Cache by cookie option.
+  - `list?: string[]` - List of cookies (required when option is 'allowlist' or 'denylist').
 - `cacheByQueryString?: CacheByQueryStringConfig` - Cache by query string settings.
-  - `option: 'ignore' | 'varies' | 'whitelist' | 'blacklist'` - Cache by query string option.
-  - `list?: string[]` - List of query string parameters to use for caching.
+  - `option: 'ignore' | 'all' | 'allowlist' | 'denylist'` - Cache by query string option.
+  - `list?: string[]` - List of query string parameters (required when option is 'allowlist' or 'denylist').
 
-### `AzionRuntimeRequestRule`
+### `AzionRules`
 
-Type definition for the request rule configuration.
-
-**Properties:**
-
-- `name: string` - Name of the request rule.
-- `description?: string` - Description of the request rule.
-- `active?: boolean` - Whether the rule is active.
-- `match: string` - Match criteria for the rule.
-- `variable?: string` - Variable to be used in the match.
-- `behavior?: RequestBehavior` - Behavior to apply when the rule matches.
-  - `setOrigin?: { name: string; type: string }` - Set a new origin.
-  - `rewrite?: string` - Rewrite the request.
-  - `setHeaders?: string[]` - Set headers.
-  - `bypassCache?: boolean | null` - Bypass cache.
-  - `httpToHttps?: boolean | null` - Force HTTPS.
-  - `redirectTo301?: string | null` - Redirect with 301 status.
-  - `redirectTo302?: string | null` - Redirect with 302 status.
-  - `forwardCookies?: boolean | null` - Forward cookies.
-  - `setCookie?: string | null` - Set a cookie.
-  - `deliver?: boolean | null` - Deliver the content.
-  - `capture?: { match: string; captured: string; subject: string }` - Capture configuration.
-  - `runFunction?: { path: string; name?: string | null }` - Run a serverless function.
-  - `setCache?: string | { name: string; browser_cache_settings_maximum_ttl?: number | null; cdn_cache_settings_maximum_ttl?: number | null }` - Set cache configuration.
-
-### `AzionResponseRule`
-
-Type definition for the response rule configuration.
+Type definition for the rule set.
 
 **Properties:**
 
-- `name: string` - Name of the response rule.
-- `description?: string` - Description of the response rule.
+- `request?: AzionRule[]` - Ruleset for Request phase.
+- `response?: AzionRule[]` - Ruleset for Response phase.
+
+### `AzionRule`
+
+Type definition for edge application rules (request/response).
+
+**Properties:**
+
+- `name: string` - Name of the rule (1-250 characters).
+- `description?: string` - Description of the rule (max 1000 characters).
+- `active?: boolean` - Whether the rule is active (default: true).
+- `criteria: Criteria[][]` - Array of criteria groups (1-5 groups, each with 1-10 criteria).
+- `behaviors: Behavior[]` - Array of behaviors to execute (1-10 behaviors).
+
+### `Criteria`
+
+Type definition for rule criteria.
+
+**Properties:**
+
+- `variable: string` - Variable to evaluate (e.g., `${uri}`, `${host}`, `${http_user_agent}`).
+- `conditional: 'if' | 'and' | 'or'` - Conditional operator.
+- `operator: string` - Comparison operator (e.g., 'matches', 'is_equal', 'starts_with').
+- `argument?: string` - Argument value (required for operators that need values).
+
+### `Behavior`
+
+Type definition for rule behaviors.
+
+**Properties:**
+
+- `type: string` - Behavior type (e.g., 'set_cache_policy', 'rewrite_request', 'run_function').
+- `attributes?: object` - Behavior-specific attributes.
+
+**Common behavior types:**
+
+- `set_cache_policy` - Set cache policy by name or ID
+- `rewrite_request` - Rewrite the request URL
+- `set_cookie` - Set a cookie
+- `add_request_header` / `add_response_header` - Add headers
+- `run_function` - Execute an edge function
+- `redirect_to_301` / `redirect_to_302` - Redirect requests
+- `deliver` - Deliver content directly
+- `enable_gzip` - Enable GZIP compression
+- `capture_match_groups` - Capture regex groups
+
+### `AzionPurge`
+
+Type definition for the purge configuration.
+
+**Properties:**
+
+- `type: 'url' | 'cachekey' | 'wildcard'` - The type of purge to be performed.
+- `items: string[]` - List of URLs or patterns to be purged (minimum 1 item).
+- `layer?: 'edge_cache' | 'tiered_cache'` - Cache layer to be purged.
+
+### `AzionNetworkList`
+
+Type definition for the network list configuration.
+
+**Properties:**
+
+- `name: string` - Name of the network list (1-250 characters).
+- `type: 'ip_cidr' | 'asn' | 'countries'` - Type of the network list.
+- `items: string[]` - List of IP CIDRs, ASNs, or countries (1-20000 items).
+- `active?: boolean` - Whether the network list is active (default: true).
+
+### `AzionEdgeFirewall`
+
+Type definition for the Edge Firewall configuration.
+
+**Properties:**
+
+- `name: string` - Name of the firewall.
+- `domains?: string[]` - List of domains associated with the firewall.
+- `active?: boolean` - Whether the firewall is active.
+- `debugRules?: boolean` - Whether debug mode is enabled for rules.
+- `edgeFunctions?: boolean` - Whether Edge Functions are enabled.
+- `networkProtection?: boolean` - Whether Network Protection is enabled.
+- `waf?: boolean` - Whether WAF is enabled.
+- `variable?: string` - Variable to be used in matches.
+- `rules?: AzionFirewallRule[]` - List of firewall rules.
+
+### `AzionFirewallRule`
+
+Type definition for firewall rules.
+
+**Properties:**
+
+- `name: string` - Name of the rule.
+- `description?: string` - Description of the rule.
 - `active?: boolean` - Whether the rule is active.
-- `match: string` - Match criteria for the rule.
-- `variable?: string` - Variable to be used in the match.
-- `behavior?: ResponseBehavior` - Behavior to apply when the rule matches.
+- `match?: string` - Match criteria for the rule (regex pattern).
+- `behavior: AzionFirewallBehavior` - Behavior to be applied when the rule matches.
 
-  - `setCookie?: string | null` - Set a cookie.
-  - `setHeaders?: string[]` - Set headers.
-  - `deliver?: boolean | null` - Deliver the content.
-  - `capture?: { match: string; captured: string; subject: string }` - Capture configuration.
-  - `enableGZIP?: boolean | null` - Enable GZIP compression.
-  - `filterCookie?: string | null` - Filter a cookie.
-  - `filterHeader?: string | null` - Filter a header.
-  - `runFunction?: { path: string; name?: string | null }` - Run a serverless function.
-  - `redirectTo301?: string | null` - Redirect with 301 status.
-  - `redirectTo302?: string | null` - Redirect with 302 status.
+### `AzionFirewallBehavior`
 
-  ### `AzionRules`
+Type definition for firewall rule behaviors.
 
-  Type definition for the rule set.
+**Properties:**
 
-  **Properties:**
+- `runFunction?: string | number` - Run a serverless function (function name or ID).
+- `setWafRuleset?: { wafMode: string; wafId: string | number }` - Set WAF ruleset.
+- `setRateLimit?: RateLimitConfig` - Set rate limit configuration.
+  - `type: 'second' | 'minute' | 'hour'` - Rate limit time window.
+  - `limitBy: 'clientIp' | 'global' | 'token'` - Rate limit criteria.
+  - `averageRateLimit: string` - Average rate limit.
+  - `maximumBurstSize: string` - Maximum burst size.
+- `deny?: boolean` - Deny the request.
+- `drop?: boolean` - Drop the request.
+- `setCustomResponse?: CustomResponseConfig` - Set custom response.
+  - `statusCode: number | string` - HTTP status code (200-499).
+  - `contentType: string` - Response content type.
+  - `contentBody: string` - Response content body.
 
-  - `request: AzionRuntimeRequestRule[]` - Ruleset for Request phase.
-  - `response?: AzionResponseRule[]` - Ruleset for Response phase.
+### `AzionWaf`
 
-  ### `AzionPurge`
+Type definition for the Web Application Firewall (WAF) configuration.
 
-  Type definition for the purge configuration.
+**Properties:**
 
-  **Properties:**
+- `id?: number` - ID of the WAF.
+- `name: string` - Name of the WAF (1-250 characters).
+- `productVersion?: string` - Product version (pattern: `\\d+\\.\\d+`, default: '1.0').
+- `engineSettings: WafEngineSettings` - WAF engine configuration.
+  - `engineVersion: '2021-Q3'` - WAF engine version.
+  - `type: 'score'` - WAF type.
+  - `attributes: WafAttributes` - WAF attributes.
+    - `rulesets: [1]` - Array containing ruleset ID 1.
+    - `thresholds: WafThreshold[]` - Array of threat thresholds (max 8 items).
 
-  - `type: 'url' | 'cachekey' | 'wildcard'` - The type of purge to be performed.
-  - `urls: string[]` - List of URLs or patterns to be purged.
-  - `method?: 'delete'` - HTTP method for the purge request.
-  - `layer?: 'edge_cache' | 'l2_cache'` - Cache layer to be purged.
+### `WafThreshold`
 
-  ### `AzionNetworkList`
+Type definition for WAF threat thresholds.
 
-  Type definition for the network list configuration.
+**Properties:**
 
-  **Properties:**
+- `threat: WafThreatType` - Threat type ('sql_injection', 'cross_site_scripting', 'remote_file_inclusion', 'directory_traversal', 'evading_tricks', 'file_upload', 'unwanted_access', 'identified_attack').
+- `sensitivity: 'highest' | 'high' | 'medium' | 'low' | 'lowest'` - Sensitivity level (default: 'medium').
 
-  - `id: number` - ID of the network list.
-  - `listType: 'ip_cidr' | 'asn' | 'countries'` - Type of the network list.
-  - `listContent: string[] | number[]` - List of IP CIDRs, ASNs, or countries
+### `AzionCustomPages`
 
-  ### `AzionFirewall`
+Type definition for custom error pages configuration.
 
-  Type definition for the Edge Firewall configuration.
+**Properties:**
 
-  **Properties:**
+- `name: string` - Name of the custom pages configuration (1-255 characters).
+- `active?: boolean` - Whether the custom pages are active (default: true).
+- `pages: CustomPage[]` - Array of custom page configurations (minimum 1 item).
 
-  - `name: string` - Name of the firewall.
-  - `domains?: string[]` - List of domains associated with the firewall.
-  - `active?: boolean` - Whether the firewall is active.
-  - `edgeFunctions?: boolean` - Whether Edge Functions are enabled.
-  - `networkProtection?: boolean` - Whether Network Protection is enabled.
-  - `waf?: boolean` - Whether WAF is enabled.
-  - `variable?: RuleVariable` - Variable to be used in matches.
-  - `rules?: AzionFirewallRule[]` - List of firewall rules.
-  - `debugRules?: boolean` - Whether debug mode is enabled for rules.
+### `CustomPage`
 
-  ### `AzionFirewallRule`
+Type definition for individual custom pages.
 
-  Type definition for firewall rules.
+**Properties:**
 
-  **Properties:**
-
-  - `name: string` - Name of the rule.
-  - `description?: string` - Description of the rule.
-  - `active?: boolean` - Whether the rule is active.
-  - `match?: string` - Match criteria for the rule.
-  - `variable?: RuleVariable` - Variable to be used in the match.
-  - `criteria?: AzionFirewallCriteria[]` - Array of criteria for complex conditions.
-  - `behavior: AzionFirewallBehavior` - Behavior to be applied when the rule matches.
-
-  ### `AzionFirewallBehavior`
-
-  Type definition for firewall rule behaviors.
-
-  **Properties:**
-
-  - `runFunction?: { path: string }` - Run a serverless function.
-  - `setWafRuleset?: { wafMode: FirewallWafMode; wafId: string }` - Set WAF ruleset.
-  - `setRateLimit?: {` - Set rate limit configuration.
-    - `type: FirewallRateLimitType` - Rate limit type (second, minute, hour).
-    - `limitBy: FirewallRateLimitBy` - Rate limit by (client_ip, global, token).
-    - `averageRateLimit: string` - Average rate limit.
-    - `maximumBurstSize: string` - Maximum burst size.
-  - `deny?: boolean` - Deny the request.
-  - `drop?: boolean` - Drop the request.
-  - `setCustomResponse?: {` - Set custom response.
-    - `statusCode: number | string` - HTTP status code (200-499).
-    - `contentType: string` - Response content type.
-    - `contentBody: string` - Response content body.
-
-  ### `AzionFirewallCriteria`
-
-  Type definition for firewall rule criteria.
-
-  **Properties:**
-
-  - `variable: RuleVariable` - Variable to be evaluated.
-  - `conditional: RuleConditional` - Conditional type.
-  - `operator: RuleOperatorWithValue | RuleOperatorWithoutValue` - Comparison operator.
-  - `inputValue?: string` - Input value for comparison (required for operators with value).
-
-  ### `AzionWaf`
-
-  Type definition for the Web Application Firewall (WAF) configuration.
-
-  **Properties:**
-
-  - `id?: number` - ID of the WAF.
-  - `name: string` - Name of the WAF.
-  - `active: boolean` - Whether the WAF is active.
-  - `mode: WafMode` - WAF mode (learning, blocking and counting).
-  - `sqlInjection?: object` - SQL Injection settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `remoteFileInclusion?: object` - Remote File Inclusion settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `directoryTraversal?: object` - Directory Traversal settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `crossSiteScripting?: object` - Cross-Site Scripting settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `evadingTricks?: object` - Evading Tricks settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `fileUpload?: object` - File Upload settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `unwantedAccess?: object` - Unwanted Access settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `identifiedAttack?: object` - Identified Attack settings.
-    - `sensitivity: string` - Sensitivity level (low, medium, high).
-  - `bypassAdresses?: string[]` - List of IP addresses to bypass the WAF.
+- `code: string` - Error code ('400', '403', '404', '405', '406', '407', '408', '409', '410', '411', '412', '413', '414', '415', '416', '417', '422', '429', '500', '501', '502', '503', '504', 'default').
+- `page: PageConfig` - Page configuration.
+  - `type?: 'page_connector'` - Page type (default: 'page_connector').
+  - `attributes: PageAttributes` - Page attributes.
+    - `connector: string | number` - Connector name or ID.
+    - `ttl?: number` - Time to live (0-31536000 seconds, default: 0).
+    - `uri?: string | null` - URI path (must start with /, max 250 characters).
+    - `customStatusCode?: number | null` - Custom status code (100-599).


### PR DESCRIPTION
BREAKING CHANGE: Major configuration structure changes

- Remove `domain` and `origin` → Add `workloads` for domain/infrastructure management
- Remove root-level `cache` → Move to `edgeApplications[].cache`
- Rename `functions` → `edgeFunctions`
- Add `edgeApplications` array with embedded cache and rules
- Add `edgeConnectors` for HTTP/storage/live ingest connections
- Add `edgeStorage` for storage bucket configuration
- Add `customPages` for error page management
- Update rules to criteria-based structure with behaviors array
- Replace cache 'whitelist'/'blacklist' → 'allowlist'/'denylist'
- Update WAF to v4 structure with engineSettings

Migration:
- Move domain config to `workloads` array
- Move cache config inside `edgeApplications`
- Rename `functions` to `edgeFunctions`
- Update cache options to allowlist/denylist
- Migrate rules to new criteria/behaviors format