### PR TITLE
fix: remove duplicate forward slashes in API endpoint URLs

### DIFF
--- a/packages/sql/src/services/api/index.ts
+++ b/packages/sql/src/services/api/index.ts
@@ -18,9 +18,9 @@ import { AzionEnvironment } from '../../types';
  */
 const getBaseUrl = (env: AzionEnvironment = 'production'): string => {
   const urls: Record<AzionEnvironment, string> = {
-    production: 'https://api.azion.com/v4//workspace/sql/databases',
-    development: '/v4//workspace/sql/databases',
-    staging: 'https://stage-api.azion.com/v4//workspace/sql/databases',
+    production: 'https://api.azion.com/v4/workspace/sql/databases',
+    development: '/v4/workspace/sql/databases',
+    staging: 'https://stage-api.azion.com/v4/workspace/sql/databases',
   };
   return urls[env];
 };

--- a/packages/storage/src/services/api/index.ts
+++ b/packages/storage/src/services/api/index.ts
@@ -21,9 +21,9 @@ import { AzionEnvironment, EdgeAccessType } from '../../types';
  */
 const getBaseUrl = (env: AzionEnvironment = 'production'): string => {
   const urls: Record<AzionEnvironment, string> = {
-    production: 'https://api.azion.com/v4//workspace/storage',
-    development: '/v4//workspace/storage',
-    staging: 'https://stage-api.azion.com/v4//workspace/storage',
+    production: 'https://api.azion.com/v4/workspace/storage',
+    development: '/v4/workspace/storage',
+    staging: 'https://stage-api.azion.com/v4/workspace/storage',
   };
   return urls[env];
 };


### PR DESCRIPTION
This pull request fixes the base URLs used for API requests in both the SQL and Storage service modules. The main change is the removal of an extra slash in the URL paths, ensuring that all environments (production, development, and staging) use the correct endpoint structure.

API endpoint corrections:

* Updated the `getBaseUrl` function in `packages/sql/src/services/api/index.ts` to remove the double slash from all environment URLs, ensuring requests target the correct SQL API endpoints.
* Updated the `getBaseUrl` function in `packages/storage/src/services/api/index.ts` to remove the double slash from all environment URLs, ensuring requests target the correct Storage API endpoints.