### PR TITLE
fix: update database response types and API endpoints for SQL client

### DIFF
--- a/packages/client/README.MD
+++ b/packages/client/README.MD
@@ -141,7 +141,7 @@ if (allDatabases) {
 
 const queryResult = await client.sql.query('SELECT * FROM users');
 if (queryResult.data) {
-  console.log(`Query executed. Rows returned: ${queryResult?.data?.rows.length}`);
+  console.log(`Query executed. Rows returned: ${queryResult.data.results?.rows?.length}`);
 }
 ```
 

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -1,6 +1,6 @@
-# Azion Edge SQL Client
+# Azion SQL Client
 
-Azion Edge SQL Client provides a simple interface to interact with the Azion Edge SQL API, allowing you to create, delete, and query databases. This client is configurable and supports both debug mode and environment variable-based configuration.
+Azion SQL Client provides a simple interface to interact with the Azion SQL API, allowing you to create, delete, and query databases. This client is configurable and supports both debug mode and environment variable-based configuration.
 
 ## Table of Contents
 
@@ -355,7 +355,7 @@ Deletes a database by its ID.
 ```javascript
 const { data, error } = await sqlClient.deleteDatabase(123);
 if (data) {
-  console.log(`Database ${data.id} deleted successfully`);
+  console.log(`Database deleted with state: ${data.state}`);
 } else {
   console.error('Failed to delete database', error);
 }
@@ -429,7 +429,7 @@ Executes a query on a specific database.
 ```javascript
 const { data, error } = await sqlClient.query('my-db', ['SELECT * FROM users']);
 if (data) {
-  console.log(`Query executed. Rows returned: ${data.rows.length}`);
+  console.log(`Query executed. Rows returned: ${data.results?.rows?.length}`);
 } else {
   console.error('Query execution failed', error);
 }
@@ -462,7 +462,7 @@ if (data) {
 
 ### `createClient`
 
-Creates an SQL client with methods to interact with Azion Edge SQL databases.
+Creates an SQL client with methods to interact with Azion SQL databases.
 
 **Parameters:**
 
@@ -500,11 +500,11 @@ The database object.
 
 - `id: number`
 - `name: string`
-- `clientId: string`
 - `status: string`
-- `createdAt: string`
-- `updatedAt: string`
-- `deletedAt: string | null`
+- `active: boolean`
+- `lastModified: string`
+- `lastEditor: string | null`
+- `productVersion: string`
 - `query: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
 - `execute: (statements: string[], options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseExecutionResponse>>`
 - `getTables: (options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>`
@@ -522,6 +522,7 @@ The response object from a database operation.
 - `columns: string[]`
 - `statement: string`
 - `rows: (number | string)[][]`
+- `error?: string`
 
 ### `AzionClientOptions`
 

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prettier": "prettier --write .",
-    "test": "jest --clearCache && jest",
+    "test": "jest --clearCache && jest --maxWorkers=1",
     "test:watch": "jest -c jest.config.js . --watch",
     "test:coverage": "jest --clearCache && jest -c jest.config.js . --coverage"
   },

--- a/packages/sql/src/index.test.ts
+++ b/packages/sql/src/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  AzionSQLClient,
   createClient,
   createDatabase,
   deleteDatabase,
@@ -10,7 +11,7 @@ import {
 } from '../src/index';
 import * as servicesApi from '../src/services/api/index';
 import * as services from '../src/services/index';
-import { AzionSQLClient } from './types';
+import { ApiCreateDatabaseResponse } from './services/api/types';
 import fetchWithErrorHandling from './utils/fetch';
 
 jest.mock('../src/services/api/index');
@@ -50,19 +51,35 @@ describe('SQL Module', () => {
   });
 
   describe('createDatabase', () => {
+    let mockApiDatabaseResponse: ApiCreateDatabaseResponse;
+    beforeEach(() => {
+      mockApiDatabaseResponse = {
+        data: {
+          active: true,
+          id: 1,
+          name: 'test-db',
+          last_editor: 'test-user',
+          last_modified: '2023-10-01T00:00:00Z',
+          product_version: '1.0.0',
+          status: 'created',
+        },
+      };
+      (servicesApi.postDatabase as jest.Mock).mockResolvedValue(mockApiDatabaseResponse);
+    });
+
     beforeAll(() => {
       jest.spyOn(console, 'log').mockImplementation();
     });
+
     it('should successfully create a database', async () => {
-      const mockResponse = { data: { id: 1, name: 'test-db' } };
-      (servicesApi.postEdgeDatabase as jest.Mock).mockResolvedValue(mockResponse);
       const result = await createDatabase('test-db', { debug: mockDebug });
       expect(result.data).toEqual(expect.objectContaining({ id: 1, name: 'test-db' }));
-      expect(servicesApi.postEdgeDatabase).toHaveBeenCalledWith(mockToken, 'test-db', true, 'production');
+      expect(servicesApi.postDatabase).toHaveBeenCalledWith(mockToken, 'test-db', true, 'production');
+      expect(result.data!.id).toEqual(mockApiDatabaseResponse.data?.id);
     });
 
     it('should return error on failure', async () => {
-      (servicesApi.postEdgeDatabase as jest.Mock).mockResolvedValue({
+      (servicesApi.postDatabase as jest.Mock).mockResolvedValue({
         error: {
           message: 'Database already exists',
           operation: 'create database',
@@ -75,19 +92,73 @@ describe('SQL Module', () => {
     });
   });
 
+  describe('getDatabase', () => {
+    const mockApiResponse = {
+      count: 1,
+      results: [
+        {
+          id: 0,
+          name: 'db-1',
+          status: 'created',
+          active: true,
+          last_modified: '2019-08-24T14:15:22Z',
+          last_editor: 'string',
+          product_version: 'string',
+        },
+      ],
+    };
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    it('should successfully retrieve a database', async () => {
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockApiResponse);
+
+      const result = await getDatabase('db-1', { debug: mockDebug });
+      expect(servicesApi.getDatabases).toHaveBeenCalledWith(
+        mockToken,
+        { page_size: 1, search: 'db-1' },
+        true,
+        'production',
+      );
+      expect(result.data).toEqual(
+        expect.objectContaining({
+          id: 0,
+          name: 'db-1',
+          status: 'created',
+          active: true,
+          lastModified: '2019-08-24T14:15:22Z',
+          lastEditor: 'string',
+          productVersion: 'string',
+        }),
+      );
+    });
+
+    it('should return error if database not found', async () => {
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue({
+        error: { message: 'Not found.', operation: 'retrieve database' },
+      });
+
+      const result = await getDatabase('test-db', { debug: mockDebug });
+      expect(result).toEqual({
+        error: { message: 'Not found.', operation: 'retrieve database' },
+      });
+    });
+  });
+
   describe('deleteDatabase', () => {
     beforeAll(() => {
       jest.spyOn(console, 'log').mockImplementation();
     });
     it('should successfully delete a database', async () => {
-      (servicesApi.deleteEdgeDatabase as jest.Mock).mockResolvedValue({ state: 'pending', data: { id: 1 } });
+      (servicesApi.deleteDatabase as jest.Mock).mockResolvedValue({ state: 'pending', data: { id: 1 } });
       const result = await deleteDatabase(1, { debug: mockDebug });
-      expect(result).toEqual({ data: { id: 1, state: 'pending' } });
-      expect(servicesApi.deleteEdgeDatabase).toHaveBeenCalledWith(mockToken, 1, true, 'production');
+      expect(result).toEqual({ data: { state: 'pending' } });
+      expect(servicesApi.deleteDatabase).toHaveBeenCalledWith(mockToken, 1, true, 'production');
     });
 
     it('should return error on failure', async () => {
-      (servicesApi.deleteEdgeDatabase as jest.Mock).mockResolvedValue({
+      (servicesApi.deleteDatabase as jest.Mock).mockResolvedValue({
         error: { message: 'Failed to delete database', operation: 'delete database' },
       });
       const result = await deleteDatabase(1, { debug: mockDebug });
@@ -97,54 +168,59 @@ describe('SQL Module', () => {
     });
   });
 
-  describe('getDatabase', () => {
-    beforeAll(() => {
-      jest.spyOn(console, 'log').mockImplementation();
-    });
-    it('should successfully retrieve a database', async () => {
-      const mockResponse = { results: [{ id: 1, name: 'test-db' }] };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponse);
-
-      const result = await getDatabase('test-db', { debug: mockDebug });
-      expect(result.data).toEqual(expect.objectContaining({ id: 1, name: 'test-db' }));
-      expect(servicesApi.getEdgeDatabases).toHaveBeenCalledWith(mockToken, { search: 'test-db' }, true, 'production');
-    });
-
-    it('should throw an error if database is not found', async () => {
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue({ results: [] });
-
-      await expect(getDatabase('test-db', { debug: mockDebug })).resolves.toEqual({
-        error: { message: "Database with name 'test-db' not found", operation: 'get database' },
-      });
-    });
-  });
-
   describe('getDatabases', () => {
     beforeAll(() => {
       jest.spyOn(console, 'log').mockImplementation();
     });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
     it('should successfully retrieve databases', async () => {
       const mockResponse = {
+        count: 2,
         results: [
-          { id: 1, name: 'test-db-1' },
-          { id: 2, name: 'test-db-2' },
+          {
+            id: 0,
+            name: 'db-1',
+            status: 'created',
+            active: true,
+            last_modified: '2019-08-24T14:15:22Z',
+            last_editor: 'string',
+            product_version: 'string',
+          },
+          {
+            id: 1,
+            name: 'db-2',
+            status: 'creating',
+            active: true,
+            last_modified: '2019-08-24T14:15:22Z',
+            last_editor: 'string',
+            product_version: 'string',
+          },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponse);
 
       const { data } = await getDatabases({ page: 1, page_size: 10 }, { debug: mockDebug });
       expect(data?.databases).toHaveLength(2);
-      expect(data!.databases![0]).toEqual(expect.objectContaining({ id: 1, name: 'test-db-1' }));
-      expect(servicesApi.getEdgeDatabases).toHaveBeenCalledWith(
-        mockToken,
-        { page: 1, page_size: 10 },
-        true,
-        'production',
+      expect(data!.databases![0]).toEqual(
+        expect.objectContaining({
+          id: 0,
+          name: 'db-1',
+          status: 'created',
+          active: true,
+          lastModified: '2019-08-24T14:15:22Z',
+          lastEditor: 'string',
+          productVersion: 'string',
+        }),
       );
+      expect(servicesApi.getDatabases).toHaveBeenCalledWith(mockToken, { page: 1, page_size: 10 }, true, 'production');
     });
 
     it('should return error if retrieval fails', async () => {
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue({
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue({
         error: { message: 'Failed to retrieve databases', operation: 'get databases' },
       });
 
@@ -153,7 +229,7 @@ describe('SQL Module', () => {
     });
   });
 
-  describe('useExecute and useQuery', () => {
+  describe('useQuery', () => {
     beforeAll(() => {
       jest.spyOn(console, 'log').mockImplementation();
     });
@@ -174,12 +250,12 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
       const mockResponse = {
         state: 'executed',
         data: [{ results: { columns: ['id', 'name'], rows: [[1, 'test']] } }],
       };
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.postQueryDatabase as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await useQuery('test-db', ['SELECT * FROM test'], { debug: mockDebug });
       expect(result.data).toEqual(
@@ -187,7 +263,13 @@ describe('SQL Module', () => {
           results: [{ columns: ['id', 'name'], rows: [[1, 'test']], statement: 'SELECT' }],
         }),
       );
-      expect(servicesApi.postQueryEdgeDatabase).toHaveBeenCalledWith(mockToken, 1, ['SELECT * FROM test'], true);
+      expect(servicesApi.postQueryDatabase).toHaveBeenCalledWith(
+        mockToken,
+        1,
+        ['SELECT * FROM test'],
+        true,
+        'production',
+      );
     });
 
     it('should throw an error if useQuery is called with an invalid statement', async () => {
@@ -197,71 +279,11 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
 
       await expect(
         useQuery('test-db', ["INSERT INTO users (id, name) VALUES (1, 'John Doe')"], { debug: mockDebug }),
       ).rejects.toThrow('Only read statements are allowed');
-    });
-
-    it('should successfully execution by useExecute', async () => {
-      const mockResponseDatabases = {
-        results: [
-          { id: 1, name: 'test-db' },
-          { id: 2, name: 'test-db-2' },
-        ],
-      };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
-      const mockResponse = {
-        data: [{ results: { columns: [], rows: [] } }],
-      };
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockResolvedValue(mockResponse);
-      const result = await useExecute('test-db', ["INSERT INTO users (id, name) VALUES (1, 'John Doe')"], {
-        debug: mockDebug,
-      });
-
-      expect(result.data).toEqual(
-        expect.objectContaining({
-          results: [{ statement: 'INSERT' }],
-        }),
-      );
-
-      expect(servicesApi.postQueryEdgeDatabase).toHaveBeenCalledWith(
-        mockToken,
-        1,
-        ["INSERT INTO users (id, name) VALUES (1, 'John Doe')"],
-        true,
-      );
-    });
-
-    it('should throw an error if useExecute is called with an invalid statement', async () => {
-      const mockResponseDatabases = {
-        results: [
-          { id: 1, name: 'test-db' },
-          { id: 2, name: 'test-db-2' },
-        ],
-      };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
-
-      await expect(useExecute('test-db', ['SELECT * FROM test'], { debug: mockDebug })).resolves.toEqual({
-        error: { message: 'Only write statements are allowed', operation: 'execute database' },
-      });
-    });
-
-    it('should return error if useExecute when token invalid', async () => {
-      const mockResponseDatabases = {
-        error: {
-          message: 'Invalid token header. No credentials provided.',
-          operation: 'get databases',
-        },
-      };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
-
-      await expect(
-        useExecute('test-db', ['INSERT INTO users (id, name) VALUES (1, "John Doe")'], { debug: mockDebug }),
-      ).resolves.toEqual({
-        error: { message: 'Invalid token header. No credentials provided.', operation: 'get databases' },
-      });
     });
 
     it('should return error if query execution fails', async () => {
@@ -271,19 +293,21 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockResolvedValue({
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+      (servicesApi.postQueryDatabase as jest.Mock).mockResolvedValue({
         error: { message: 'Error executing query', operation: 'executing query' },
       });
 
       const result = await useQuery('test-db', ['SELECT * FROM test'], { debug: mockDebug });
       expect(result).toEqual({
-        error: { message: 'Error executing query', operation: 'executing query' },
+        error: { message: 'Error executing query', operation: 'apiQuery' },
       });
     });
 
     it('should successfully execute useQuery with apiQuery called', async () => {
-      const spyApiQuery = jest.spyOn(services, 'apiQuery').mockResolvedValue({ data: { toObject: () => null } });
+      const spyApiQuery = jest.spyOn(services, 'apiQuery').mockResolvedValue({
+        data: { toObject: () => null, state: 'executed' },
+      });
 
       await useQuery('test-db', ['SELECT * FROM test'], { debug: mockDebug, env: 'production' });
 
@@ -301,7 +325,7 @@ describe('SQL Module', () => {
       (globalThis as any).Azion = { Sql: {} };
       const spyRuntimeQuery = jest
         .spyOn(services, 'runtimeQuery')
-        .mockResolvedValue({ data: { toObject: () => null } });
+        .mockResolvedValue({ data: { state: 'executed-runtime', toObject: () => null } });
 
       await useQuery('test-db', ['SELECT * FROM test'], { debug: mockDebug });
 
@@ -316,49 +340,52 @@ describe('SQL Module', () => {
 
     it('should return error if useQuery when statement some invalid', async () => {
       const mockResponseDatabases = {
+        count: 2,
         results: [
           { id: 1, name: 'test-db' },
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
-
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockImplementation(
-        jest.requireActual('../src/services/api/index').postQueryEdgeDatabase,
-      );
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
 
       (fetchWithErrorHandling as jest.Mock).mockResolvedValue({
         state: 'executed',
         data: [
           {
             results: {
-              columns: ['schema', 'name', 'type', 'ncol', 'wr', 'strict'],
-              rows: [
-                ['main', 'sqlite_schema', 'table', 5, 0, 0],
-                ['temp', 'sqlite_temp_schema', 'table', 5, 0, 0],
-              ],
-              rows_read: 0,
+              columns: ['id', 'name'],
+              rows: [[1, 'john']],
+              rows_read: 1,
               rows_written: 0,
-              query_duration_ms: 0.058,
+              query_duration_ms: 0.161,
             },
           },
           {
             error: 'no such table: main',
           },
-          null,
         ],
       });
 
+      (servicesApi.postQueryDatabase as jest.Mock).mockImplementation(
+        jest.requireActual('../src/services/api/index').postQueryDatabase,
+      );
       await expect(
-        useQuery('test-db', ['pragma table_list', 'select * from main', 'select * from sqlite_schema'], {
+        useQuery('test-db', ['pragma table_list', 'select * from main'], {
           debug: mockDebug,
         }),
       ).resolves.toEqual(
         expect.objectContaining({
-          error: {
+          data: expect.objectContaining({
+            state: 'executed',
+            results: expect.arrayContaining([
+              expect.anything(),
+              expect.objectContaining({ error: 'no such table: main' }),
+            ]),
+          }),
+          error: expect.objectContaining({
             message: 'no such table: main',
-            operation: 'post query',
-          },
+            operation: 'apiQuery',
+          }),
         }),
       );
     });
@@ -370,11 +397,7 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
-
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockImplementation(
-        jest.requireActual('../src/services/api/index').postQueryEdgeDatabase,
-      );
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
 
       (fetchWithErrorHandling as jest.Mock).mockResolvedValue({
         state: 'executed',
@@ -400,30 +423,24 @@ describe('SQL Module', () => {
         ],
       });
 
+      (servicesApi.postQueryDatabase as jest.Mock).mockImplementation(
+        jest.requireActual('../src/services/api/index').postQueryDatabase,
+      );
+
       await expect(
-        useQuery('test-db', ['pragma table_list', 'select * from main', 'select * from sqlite_schema'], {
+        useQuery('test-db', ['pragma table_list', 'select * from sqlite_schema', 'select * from main'], {
           debug: mockDebug,
         }),
       ).resolves.toEqual(
         expect.objectContaining({
           data: expect.objectContaining({
             state: 'executed',
-            results: [
-              {
-                columns: ['schema', 'name', 'type', 'ncol', 'wr', 'strict'],
-                rows: [
-                  ['main', 'sqlite_schema', 'table', 5, 0, 0],
-                  ['temp', 'sqlite_temp_schema', 'table', 5, 0, 0],
-                ],
-                statement: 'pragma',
-              },
-              { columns: ['id', 'name'], rows: [[1, 'test']], statement: 'select' },
-            ],
+            results: expect.arrayContaining([
+              expect.anything(),
+              expect.anything(),
+              expect.objectContaining({ error: 'no such table: main' }),
+            ]),
           }),
-          error: {
-            message: 'no such table: main',
-            operation: 'post query',
-          },
         }),
       );
     });
@@ -435,10 +452,10 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
 
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockImplementation(
-        jest.requireActual('../src/services/api/index').postQueryEdgeDatabase,
+      (servicesApi.postQueryDatabase as jest.Mock).mockImplementation(
+        jest.requireActual('../src/services/api/index').postQueryDatabase,
       );
 
       (fetchWithErrorHandling as jest.Mock).mockResolvedValue({
@@ -461,6 +478,79 @@ describe('SQL Module', () => {
     });
   });
 
+  describe('useExecute', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+    afterAll(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).Azion = {};
+    });
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('should successfully execution by useExecute', async () => {
+      const mockResponseDatabases = {
+        results: [
+          { id: 1, name: 'test-db' },
+          { id: 2, name: 'test-db-2' },
+        ],
+      };
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+      const mockResponse = {
+        data: [{ results: { columns: [], rows: [] } }],
+      };
+      (servicesApi.postQueryDatabase as jest.Mock).mockResolvedValue(mockResponse);
+      const result = await useExecute('test-db', ["INSERT INTO users (id, name) VALUES (1, 'John Doe')"], {
+        debug: mockDebug,
+      });
+
+      expect(result.data).toEqual(
+        expect.objectContaining({
+          results: [{ statement: 'INSERT' }],
+        }),
+      );
+
+      expect(servicesApi.postQueryDatabase).toHaveBeenCalledWith(
+        mockToken,
+        1,
+        ["INSERT INTO users (id, name) VALUES (1, 'John Doe')"],
+        true,
+        'production',
+      );
+    });
+
+    it('should throw an error if useExecute is called with an invalid statement', async () => {
+      const mockResponseDatabases = {
+        results: [
+          { id: 1, name: 'test-db' },
+          { id: 2, name: 'test-db-2' },
+        ],
+      };
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+
+      await expect(useExecute('test-db', ['SELECT * FROM test'], { debug: mockDebug })).resolves.toEqual({
+        error: { message: 'Only write statements are allowed', operation: 'execute database' },
+      });
+    });
+
+    it('should return error if useExecute when token invalid', async () => {
+      const mockResponseDatabases = {
+        error: {
+          message: 'Invalid token header. No credentials provided.',
+          operation: 'get databases',
+        },
+      };
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+
+      await expect(
+        useExecute('test-db', ['INSERT INTO users (id, name) VALUES (1, "John Doe")'], { debug: mockDebug }),
+      ).resolves.toEqual({
+        error: { message: 'Invalid token header. No credentials provided.', operation: 'get databases' },
+      });
+    });
+  });
+
   describe('getTables', () => {
     it('should successfully list tables', async () => {
       const mockResponseDatabases = {
@@ -469,7 +559,7 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponseDatabases);
       const mockResponse = {
         data: [
           {
@@ -480,7 +570,7 @@ describe('SQL Module', () => {
           },
         ],
       };
-      (servicesApi.postQueryEdgeDatabase as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.postQueryDatabase as jest.Mock).mockResolvedValue(mockResponse);
 
       const result = await getTables('test-db', { debug: mockDebug });
       expect(result.data).toEqual(
@@ -494,7 +584,13 @@ describe('SQL Module', () => {
           ],
         }),
       );
-      expect(servicesApi.postQueryEdgeDatabase).toHaveBeenCalledWith(mockToken, 1, ['PRAGMA table_list'], true);
+      expect(servicesApi.postQueryDatabase).toHaveBeenCalledWith(
+        mockToken,
+        1,
+        ['PRAGMA table_list'],
+        true,
+        'production',
+      );
     });
   });
 
@@ -509,31 +605,35 @@ describe('SQL Module', () => {
       client = createClient({ token: 'custom-token', options: { debug: false } });
     });
 
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('should call createDatabase method', async () => {
       const mockResponse = { data: { id: 1, name: 'test-db' } };
-      (servicesApi.postEdgeDatabase as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.postDatabase as jest.Mock).mockResolvedValue(mockResponse);
 
       await client.createDatabase('test-db');
-      expect(servicesApi.postEdgeDatabase).toHaveBeenCalledWith('custom-token', 'test-db', false, 'production');
+      expect(servicesApi.postDatabase).toHaveBeenCalledWith('custom-token', 'test-db', false, 'production');
     });
 
     it('should call deleteDatabase method', async () => {
       const mockResponse = { data: { message: 'Database deleted' }, state: 'success' };
-      (servicesApi.deleteEdgeDatabase as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.deleteDatabase as jest.Mock).mockResolvedValue(mockResponse);
 
       await client.deleteDatabase(1);
-      expect(servicesApi.deleteEdgeDatabase).toHaveBeenCalledWith('custom-token', 1, false, 'production');
+      expect(servicesApi.deleteDatabase).toHaveBeenCalledWith('custom-token', 1, false, 'production');
     });
 
     it('should call getDatabase method', async () => {
       const mockResponse = { results: [{ id: 1, name: 'test-db' }] };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponse);
       if (client.getDatabase) {
         await client.getDatabase('test-db');
       }
-      expect(servicesApi.getEdgeDatabases).toHaveBeenCalledWith(
+      expect(servicesApi.getDatabases).toHaveBeenCalledWith(
         'custom-token',
-        { search: 'test-db' },
+        { search: 'test-db', page_size: 1 },
         false,
         'production',
       );
@@ -546,14 +646,81 @@ describe('SQL Module', () => {
           { id: 2, name: 'test-db-2' },
         ],
       };
-      (servicesApi.getEdgeDatabases as jest.Mock).mockResolvedValue(mockResponse);
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockResponse);
 
       await client.getDatabases({ page: 1, page_size: 10 });
-      expect(servicesApi.getEdgeDatabases).toHaveBeenCalledWith(
+      expect(servicesApi.getDatabases).toHaveBeenCalledWith(
         'custom-token',
         { page: 1, page_size: 10 },
         false,
         'production',
+      );
+    });
+  });
+
+  describe('toJson method', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should convert query execution response to JSON object', async () => {
+      const mockResponse = {
+        state: 'executed',
+        data: [
+          {
+            results: {
+              columns: ['id', 'name'],
+              rows: [
+                [1, 'test'],
+                [2, 'example'],
+              ],
+            },
+          },
+        ],
+      };
+      const mockDBResponse = {
+        count: 1,
+        results: [
+          {
+            id: 0,
+            name: 'db-1',
+            status: 'created',
+            active: true,
+            last_modified: '2019-08-24T14:15:22Z',
+            last_editor: 'string',
+            product_version: 'string',
+          },
+        ],
+      };
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockDBResponse);
+
+      const resultDatabase = await getDatabase('db-1', { debug: mockDebug });
+      (servicesApi.getDatabases as jest.Mock).mockResolvedValue(mockDBResponse);
+      (servicesApi.postQueryDatabase as jest.Mock).mockResolvedValue(mockResponse);
+      const result = await resultDatabase.data?.query(['SELECT * FROM test'], { debug: mockDebug });
+      const toObjectResponse = result?.data?.toObject();
+      expect(toObjectResponse).toEqual(
+        expect.objectContaining({
+          results: [
+            {
+              rows: [
+                {
+                  id: 1,
+                  name: 'test',
+                },
+                {
+                  id: 2,
+                  name: 'example',
+                },
+              ],
+              statement: 'SELECT',
+            },
+          ],
+        }),
       );
     });
   });

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -1,19 +1,20 @@
-import { deleteEdgeDatabase, getEdgeDatabases, postEdgeDatabase } from './services/api/index';
-import { ApiDatabaseResponse } from './services/api/types';
+import { deleteDatabase, getDatabases, postDatabase } from './services/api/index';
+import { ApiDatabase } from './services/api/types';
 import { apiQuery, runtimeQuery } from './services/index';
 import { getAzionSql } from './services/runtime/index';
-import type {
-  AzionClientOptions,
-  AzionDatabase,
-  AzionDatabaseCollectionOptions,
-  AzionDatabaseCollections,
-  AzionDatabaseDeleteResponse,
-  AzionDatabaseQueryResponse,
-  AzionDatabaseResponse,
-  AzionEnvironment,
-  AzionSQLClient,
-  CreateAzionSQLClient,
+import {
+  type AzionClientOptions,
+  type AzionDatabase,
+  type AzionDatabaseCollectionOptions,
+  type AzionDatabaseCollections,
+  type AzionDatabaseDeleteResponse,
+  type AzionDatabaseQueryResponse,
+  type AzionDatabaseResponse,
+  type AzionEnvironment,
+  type AzionSQLClient,
+  type CreateAzionSQLClient,
 } from './types';
+import { handleUnknownError } from './utils/validations/error-response';
 
 /**
  * Determines if the code is running in a browser environment.
@@ -55,6 +56,18 @@ const resolveClientOptions = (options?: AzionClientOptions): AzionClientOptions 
   env: resolveEnv(options?.env),
 });
 
+const AzionDatabaseTransform = {
+  parse: (data: ApiDatabase): Partial<AzionDatabase> => ({
+    id: data.id,
+    name: data.name,
+    status: data.status,
+    active: data.active,
+    lastModified: data.last_modified,
+    lastEditor: data.last_editor,
+    productVersion: data.product_version,
+  }),
+};
+
 /**
  * Creates a new database.
  * @param token Token to authenticate with the API.
@@ -67,27 +80,32 @@ const createDatabaseMethod = async (
   name: string,
   options?: AzionClientOptions,
 ): Promise<AzionDatabaseResponse<AzionDatabase>> => {
-  const resolvedOptions = resolveClientOptions(options);
-  const apiResponse = await postEdgeDatabase(resolveToken(token), name, resolvedOptions.debug, resolvedOptions.env);
-  if (apiResponse.data) {
+  try {
+    const resolvedOptions = resolveClientOptions(options);
+    const apiResponse = await postDatabase(resolveToken(token), name, resolvedOptions.debug, resolvedOptions.env);
+    if (apiResponse.data) {
+      const databaseTransformed: Partial<AzionDatabase> = AzionDatabaseTransform.parse(apiResponse.data);
+      return {
+        data: {
+          state: apiResponse.state ?? 'executed',
+          ...databaseTransformed,
+          query: (statements: string[]) => queryDatabaseMethod(resolveToken(token), name, statements, resolvedOptions),
+          execute: (statements: string[]) =>
+            executeDatabaseMethod(resolveToken(token), name, statements, resolvedOptions),
+          getTables: (options?: AzionClientOptions) =>
+            listTablesWrapper(name, {
+              ...options,
+              debug: resolvedOptions.debug,
+            }),
+        },
+      } as AzionDatabaseResponse<AzionDatabase>;
+    }
     return {
-      data: {
-        state: apiResponse.state,
-        ...apiResponse.data,
-        query: (statements: string[]) => queryDatabaseMethod(resolveToken(token), name, statements, resolvedOptions),
-        execute: (statements: string[]) =>
-          executeDatabaseMethod(resolveToken(token), name, statements, resolvedOptions),
-        getTables: (options?: AzionClientOptions) =>
-          listTablesWrapper(name, {
-            ...options,
-            debug: resolvedOptions.debug,
-          }),
-      },
-    } as AzionDatabaseResponse<AzionDatabase>;
+      error: apiResponse.error,
+    };
+  } catch (error) {
+    return handleUnknownError(error, 'create database');
   }
-  return {
-    error: apiResponse.error,
-  };
 };
 
 /**
@@ -103,12 +121,11 @@ const deleteDatabaseMethod = async (
   options?: AzionClientOptions,
 ): Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>> => {
   const resolvedOptions = resolveClientOptions(options);
-  const apiResponse = await deleteEdgeDatabase(resolveToken(token), id, resolvedOptions.debug, resolvedOptions.env);
-  if (apiResponse?.data) {
+  const apiResponse = await deleteDatabase(resolveToken(token), id, resolvedOptions.debug, resolvedOptions.env);
+  if (apiResponse?.state) {
     return {
       data: {
         state: apiResponse.state ?? 'executed',
-        id: apiResponse.data.id,
       },
     };
   }
@@ -129,52 +146,48 @@ const getDatabaseMethod = async (
   name: string,
   options?: AzionClientOptions,
 ): Promise<AzionDatabaseResponse<AzionDatabase>> => {
-  const resolvedOptions = resolveClientOptions(options);
-  if (!name || name === '') {
+  try {
+    const resolvedOptions = resolveClientOptions(options);
+
+    const apiResponse = await getDatabases(
+      resolveToken(token),
+      { search: name, page_size: 1 },
+      resolvedOptions.debug,
+      resolvedOptions.env,
+    );
+
+    if (apiResponse.results && apiResponse.results.length > 0) {
+      const filteredResults = apiResponse.results.filter((db: ApiDatabase) => db.name === name);
+      if (filteredResults.length === 0) {
+        return {
+          error: {
+            message: `Database ${name} not found`,
+            operation: 'get database',
+          },
+        };
+      }
+      const databaseTransformed: Partial<AzionDatabase> = AzionDatabaseTransform.parse(filteredResults[0]);
+      return {
+        data: {
+          ...databaseTransformed,
+          query: (statements: string[]) => queryDatabaseMethod(resolveToken(token), name, statements, resolvedOptions),
+          execute: (statements: string[]) =>
+            executeDatabaseMethod(resolveToken(token), name, statements, resolvedOptions),
+          getTables: (options?: AzionClientOptions) =>
+            listTablesWrapper(name, {
+              ...options,
+              debug: resolvedOptions.debug,
+            }),
+        },
+      } as AzionDatabaseResponse<AzionDatabase>;
+    }
+
     return {
-      error: {
-        message: 'Database name is required',
-        operation: 'get database',
-      },
+      error: apiResponse.error,
     };
+  } catch (error) {
+    return handleUnknownError(error, 'get database');
   }
-  const databaseResponse = await getEdgeDatabases(
-    resolveToken(token),
-    { search: name },
-    resolvedOptions.debug,
-    resolvedOptions.env,
-  );
-  if (!databaseResponse?.results || databaseResponse?.results?.length === 0) {
-    return {
-      error: {
-        message: `Database with name '${name}' not found`,
-        operation: 'get database',
-      },
-    };
-  }
-  const databaseResult = databaseResponse?.results[0];
-  if (!databaseResult || databaseResult.id === undefined || databaseResult.name !== name) {
-    return {
-      error: {
-        message: `Database with name '${name}' not found`,
-        operation: 'get database',
-      },
-    };
-  }
-  return {
-    data: {
-      ...databaseResult,
-      query: (statements: string[]) =>
-        queryDatabaseMethod(resolveToken(token), databaseResult.name, statements, resolvedOptions),
-      execute: (statements: string[]) =>
-        executeDatabaseMethod(resolveToken(token), databaseResult.name, statements, resolvedOptions),
-      getTables: (options?: AzionClientOptions) =>
-        listTablesWrapper(databaseResult.name, {
-          ...options,
-          debug: resolvedOptions.debug,
-        }),
-    },
-  } as AzionDatabaseResponse<AzionDatabase>;
 };
 
 /**
@@ -190,11 +203,29 @@ const getDatabasesMethod = async (
   options?: AzionClientOptions,
 ): Promise<AzionDatabaseResponse<AzionDatabaseCollections>> => {
   const resolvedOptions = resolveClientOptions(options);
-  const apiResponse = await getEdgeDatabases(resolveToken(token), params, resolvedOptions.debug, resolvedOptions.env);
-  if (apiResponse?.results && apiResponse.results.length > 0) {
-    const databases = apiResponse.results.map((db: ApiDatabaseResponse) => {
-      return {
-        ...db,
+  const apiResponse = await getDatabases(resolveToken(token), params, resolvedOptions.debug, resolvedOptions.env);
+
+  // If the API response contains an error, return it
+  if (apiResponse.error) {
+    return {
+      error: apiResponse.error,
+    };
+  }
+  // If no results are found, return an empty collection with count
+  if (!apiResponse?.results || apiResponse?.results?.length === 0) {
+    return {
+      data: {
+        count: apiResponse.count ?? 0,
+        databases: [],
+      },
+    };
+  }
+
+  return {
+    data: {
+      count: apiResponse.count ?? 0,
+      databases: apiResponse.results.map((db: ApiDatabase) => ({
+        ...AzionDatabaseTransform.parse(db),
         query: (statements: string[]): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
           queryDatabaseMethod(resolveToken(token), db.name, statements, resolvedOptions),
         execute: (statements: string[]): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> =>
@@ -204,18 +235,9 @@ const getDatabasesMethod = async (
             ...options,
             debug: resolvedOptions.debug,
           }),
-      };
-    });
-    return {
-      data: {
-        count: apiResponse.count,
-        databases,
-      },
-    };
-  }
-  return {
-    error: apiResponse.error,
-  };
+      })),
+    },
+  } as AzionDatabaseResponse<AzionDatabaseCollections>;
 };
 
 /**
@@ -471,7 +493,7 @@ const useExecute = async (
   executeDatabaseMethod(resolveToken(), name, statements, options);
 
 /**
- * Creates an SQL client with methods to interact with Azion Edge SQL databases.
+ * Creates an SQL client with methods to interact with Azion SQL databases.
  *
  * @param {Partial<{ token?: string; options?: AzionClientOptions; }>} [config] - Configuration options for the SQL client.
  * @returns {AzionSQLClient} An object with methods to interact with SQL databases.
@@ -496,13 +518,13 @@ const client: CreateAzionSQLClient = (
 
   const client: AzionSQLClient = {
     createDatabase: (name: string): Promise<AzionDatabaseResponse<AzionDatabase>> =>
-      createDatabaseMethod(tokenValue, name, { ...config, debug: debugValue }),
+      createDatabaseMethod(tokenValue, name, { ...config?.options, debug: debugValue }),
     deleteDatabase: (id: number): Promise<AzionDatabaseResponse<AzionDatabaseDeleteResponse>> =>
-      deleteDatabaseMethod(tokenValue, id, { ...config, debug: debugValue }),
+      deleteDatabaseMethod(tokenValue, id, { ...config?.options, debug: debugValue }),
     getDatabase: (name: string): Promise<AzionDatabaseResponse<AzionDatabase>> =>
-      getDatabaseMethod(tokenValue, name, { ...config, debug: debugValue }),
+      getDatabaseMethod(tokenValue, name, { ...config?.options, debug: debugValue }),
     getDatabases: (params?: AzionDatabaseCollectionOptions): Promise<AzionDatabaseResponse<AzionDatabaseCollections>> =>
-      getDatabasesMethod(tokenValue, params, { ...config, debug: debugValue }),
+      getDatabasesMethod(tokenValue, params, { ...config?.options, debug: debugValue }),
   } as const;
 
   return client;

--- a/packages/sql/src/services/api/index.test.ts
+++ b/packages/sql/src/services/api/index.test.ts
@@ -1,0 +1,348 @@
+import { deleteDatabase, getDatabases, postDatabase, postQueryDatabase, retrieveDatabase } from '.';
+import * as fetchWithErrorHandling from '../../utils/fetch/index';
+
+jest.mock('../../utils/fetch/index', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('SQL API Service', () => {
+  describe('postDatabase', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should create a database successfully', async () => {
+      const dbName = 'test_db';
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        state: 'executed',
+        data: {
+          id: 0,
+          name: dbName,
+          status: 'creating',
+          active: true,
+          last_modified: '2019-08-24T14:15:22Z',
+          last_editor: 'string',
+          product_version: 'string',
+        },
+      });
+      const result = await postDatabase('valid_token', dbName, true, 'production');
+      expect(result).toEqual({
+        state: 'executed',
+        data: expect.objectContaining({
+          id: 0,
+          name: dbName,
+          status: 'creating',
+          active: true,
+          last_editor: 'string',
+          product_version: 'string',
+        }),
+      });
+    });
+
+    it('should create a database with error handling', async () => {
+      const dbName = 'test_db';
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        errors: [
+          {
+            status: 'str',
+            code: 'strin',
+            title: 'string',
+            detail: 'error message',
+            source: {
+              pointer: 'string',
+              parameter: 'string',
+              header: 'string',
+            },
+            meta: null,
+          },
+        ],
+      });
+      const result = await postDatabase('valid_token', dbName, true, 'production');
+      expect(result).toEqual({
+        error: expect.objectContaining({
+          message: 'error message',
+          operation: 'post database',
+        }),
+      });
+    });
+  });
+
+  describe('retrieveDatabase', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should retrieve a database successfully', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        data: {
+          id: 0,
+          name: 'test_db',
+          status: 'creating',
+          active: true,
+          last_modified: '2019-08-24T14:15:22Z',
+          last_editor: 'string',
+          product_version: 'string',
+        },
+      });
+      const result = await retrieveDatabase('valid_token', 1, true, 'production');
+      expect(result).toEqual({
+        data: {
+          id: 0,
+          name: 'test_db',
+          status: 'creating',
+          last_modified: '2019-08-24T14:15:22Z',
+          active: true,
+          last_editor: 'string',
+          product_version: 'string',
+        },
+      });
+    });
+
+    it('should handle errors when retrieving a database', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        errors: [
+          {
+            status: 'str',
+            code: 'strin',
+            title: 'string',
+            detail: 'error message',
+            source: {
+              pointer: 'string',
+              parameter: 'string',
+              header: 'string',
+            },
+            meta: null,
+          },
+        ],
+      });
+      const result = await retrieveDatabase('valid_token', 1, true, 'production');
+      expect(result).toEqual({
+        error: expect.objectContaining({
+          message: 'error message',
+          operation: 'retrieve database',
+        }),
+      });
+    });
+  });
+
+  describe('deleteDatabase', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should delete a database successfully with state executed', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        state: 'executed',
+      });
+      const result = await deleteDatabase('valid_token', 1, true, 'production');
+      expect(result).toEqual({
+        state: 'executed',
+      });
+    });
+
+    it('should delete a database successfully with state pending', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        state: 'pending',
+      });
+      const result = await deleteDatabase('valid_token', 1, true, 'production');
+      expect(result).toEqual({
+        state: 'pending',
+      });
+    });
+
+    it('should handle errors when deleting a database', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        errors: [
+          {
+            status: 'str',
+            code: 'strin',
+            title: 'string',
+            detail: 'error message',
+            source: {
+              pointer: 'string',
+              parameter: 'string',
+              header: 'string',
+            },
+            meta: null,
+          },
+        ],
+      });
+      const result = await deleteDatabase('valid_token', 1, true, 'production');
+      expect(result).toEqual({
+        error: expect.objectContaining({
+          message: 'error message',
+          operation: 'delete database',
+        }),
+      });
+    });
+  });
+
+  describe('postQueryDatabase', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should execute a query successfully with state executed', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        state: 'executed',
+        data: [
+          {
+            results: {
+              columns: [null],
+              rows: [null],
+            },
+          },
+        ],
+      });
+      const result = await postQueryDatabase('valid_token', 1, ['SELECT * FROM test'], true, 'production');
+      expect(result).toEqual({
+        state: 'executed',
+        data: [
+          {
+            results: {
+              columns: [null],
+              rows: [null],
+            },
+          },
+        ],
+      });
+    });
+
+    it('should execute a query successfully with state pending', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        state: 'pending',
+        data: [
+          {
+            results: {
+              columns: [null],
+              rows: [null],
+            },
+          },
+        ],
+      });
+      const result = await postQueryDatabase('valid_token', 1, ['SELECT * FROM test'], true, 'production');
+      expect(result).toEqual({
+        state: 'pending',
+        data: [
+          {
+            results: {
+              columns: [null],
+              rows: [null],
+            },
+          },
+        ],
+      });
+    });
+
+    it('should handle errors when executing a query', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        errors: [
+          {
+            status: 'str',
+            code: 'strin',
+            title: 'string',
+            detail: 'error message',
+            source: {
+              pointer: 'string',
+              parameter: 'string',
+              header: 'string',
+            },
+            meta: null,
+          },
+        ],
+      });
+      const result = await postQueryDatabase('valid_token', 1, ['SELECT * FROM test'], true, 'production');
+      expect(result).toEqual({
+        error: expect.objectContaining({
+          message: 'error message',
+          operation: 'post query',
+        }),
+      });
+    });
+  });
+
+  describe('getDatabases', () => {
+    beforeAll(() => {
+      jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should get all EdgeDBs successfully', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        count: 10,
+        results: [
+          {
+            id: 0,
+            name: 'string',
+            status: 'created',
+            active: true,
+            last_modified: '2019-08-24T14:15:22Z',
+            last_editor: 'string',
+            product_version: 'string',
+          },
+        ],
+      });
+      const result = await getDatabases('valid_token', { search: 'test-db' }, true, 'production');
+      expect(result).toEqual({
+        count: 10,
+        results: [
+          {
+            id: 0,
+            name: 'string',
+            status: 'created',
+            active: true,
+            last_modified: '2019-08-24T14:15:22Z',
+            last_editor: 'string',
+            product_version: 'string',
+          },
+        ],
+      });
+    });
+
+    it('should handle errors when get EdgeDBs', async () => {
+      (fetchWithErrorHandling.default as jest.Mock).mockResolvedValue({
+        errors: [
+          {
+            status: 'str',
+            code: 'strin',
+            title: 'string',
+            detail: 'error message',
+            source: {
+              pointer: 'string',
+              parameter: 'string',
+              header: 'string',
+            },
+            meta: null,
+          },
+        ],
+      });
+      const result = await getDatabases('valid_token', { page: 2 }, true, 'production');
+      expect(result).toEqual({
+        error: expect.objectContaining({
+          message: 'error message',
+          operation: 'get databases',
+        }),
+      });
+    });
+  });
+});

--- a/packages/sql/src/services/api/index.ts
+++ b/packages/sql/src/services/api/index.ts
@@ -2,13 +2,14 @@
 import { AzionDatabaseCollectionOptions } from '../../types';
 import { limitArraySize } from '../../utils';
 import fetchWithErrorHandling from '../../utils/fetch';
-import type {
-  ApiCreateDatabaseResponse,
-  ApiDeleteDatabaseResponse,
-  ApiListDatabasesResponse,
-  ApiQueryExecutionResponse,
+import {
+  type ApiCreateDatabaseResponse,
+  type ApiDatabaseListResponse,
+  type ApiDeleteDatabaseResponse,
+  type ApiError,
+  type ApiQueryExecutionResponse,
+  type ApiRetrieveDatabaseResponse,
 } from './types';
-import { hasDataError } from './utils';
 
 import { AzionEnvironment } from '../../types';
 
@@ -17,9 +18,9 @@ import { AzionEnvironment } from '../../types';
  */
 const getBaseUrl = (env: AzionEnvironment = 'production'): string => {
   const urls: Record<AzionEnvironment, string> = {
-    production: 'https://api.azion.com/v4/edge_sql/databases',
-    development: '/v4/edge_sql/databases',
-    staging: 'https://stage-api.azion.com/v4/edge_sql/databases',
+    production: 'https://api.azion.com/v4/workspace/sql/databases',
+    development: '/v4/workspace/sql/databases',
+    staging: 'https://stage-api.azion.com/v4/workspace/sql/databases',
   };
   return urls[env];
 };
@@ -60,8 +61,27 @@ const buildFetchOptions = (method: string, headers: Record<string, string>, body
   return options;
 };
 
-const handleApiError = (fields: string[], data: any, operation: string) => {
-  let error = { message: 'Error unknown', operation: operation };
+const handleApiError = (fields: string[], data: any, operation: string): ApiError => {
+  let error: ApiError = { message: 'Error unknown', operation: operation };
+
+  if (data.errors && Array.isArray(data.errors) && data.errors.length > 0) {
+    const firstError = data.errors[0];
+    if (firstError.detail) {
+      error = {
+        message: firstError.detail,
+        operation: operation,
+      };
+      return error;
+    }
+    if (firstError.title) {
+      error = {
+        message: firstError.title,
+        operation: operation,
+      };
+      return error;
+    }
+  }
+
   fields.forEach((field: string) => {
     if (data[field]) {
       const message = Array.isArray(data[field]) ? data[field].join(', ') : data[field];
@@ -75,9 +95,9 @@ const handleApiError = (fields: string[], data: any, operation: string) => {
 };
 
 /**
- * Creates a new Edge Database.
+ * Creates a new Database.
  */
-const postEdgeDatabase = async (
+const postDatabase = async (
   token: string,
   name: string,
   debug?: boolean,
@@ -90,39 +110,31 @@ const postEdgeDatabase = async (
 
     const result = await fetchWithErrorHandling(baseUrl, options, debug);
 
-    if (!result.state) {
-      result.error = handleApiError(['detail'], result, 'post database');
+    if (result.errors) {
       return {
-        error: result.error ?? JSON.stringify(result),
+        error: handleApiError([], result, 'post database'),
       };
     }
+
+    const dataResult = result.data;
 
     if (debug) console.log('Response Post Database', JSON.stringify(result));
     return {
       state: result.state,
-      data: {
-        clientId: result.data.client_id,
-        createdAt: result.data.created_at,
-        deletedAt: result.data.deleted_at,
-        id: result.data.id,
-        isActive: result.data.is_active,
-        name: result.data.name,
-        status: result.data.status,
-        updatedAt: result.data.updated_at,
-      },
+      data: dataResult,
     };
-  } catch (error: any) {
+  } catch (error) {
     if (debug) console.error('Error creating EdgeDB:', error);
     return {
-      error: { message: error.toString(), operation: 'post database' },
+      error: { message: (error as Error).message, operation: 'post database' },
     };
   }
 };
 
 /**
- * Deletes an existing Edge Database.
+ * Deletes an existing Database.
  */
-const deleteEdgeDatabase = async (
+const deleteDatabase = async (
   token: string,
   id: number,
   debug?: boolean,
@@ -135,18 +147,12 @@ const deleteEdgeDatabase = async (
 
     const result = await fetchWithErrorHandling(`${baseUrl}/${id}`, options, debug);
 
-    if (!result.state) {
-      result.error = handleApiError(['detail'], result, 'delete database');
+    if (result.errors) {
       return {
-        error: result.error ?? JSON.stringify(result),
+        error: handleApiError([], result, 'delete database'),
       };
     }
-    return {
-      state: result.state,
-      data: {
-        id,
-      },
-    };
+    return result;
   } catch (error: any) {
     if (debug) console.error('Error deleting EdgeDB:', error);
     return {
@@ -156,9 +162,9 @@ const deleteEdgeDatabase = async (
 };
 
 /**
- * Executes a query on an Edge Database.
+ * Executes a query on an Database.
  */
-const postQueryEdgeDatabase = async (
+const postQueryDatabase = async (
   token: string,
   id: number,
   statements: string[],
@@ -172,25 +178,13 @@ const postQueryEdgeDatabase = async (
 
     const result = await fetchWithErrorHandling(`${baseUrl}/${id}/query`, options, debug);
 
-    if (!result.data || !Array.isArray(result.data)) {
-      result.error = handleApiError(['detail'], result, 'post query');
+    if (result.errors) {
       return {
-        error: result.error ?? JSON.stringify(result),
+        error: handleApiError([], result, 'post query'),
       };
     }
 
-    const hasErrorResult = hasDataError(result.data);
-
-    if (hasErrorResult) {
-      return {
-        error: {
-          message: hasErrorResult?.message,
-          operation: 'post query',
-        },
-        state: result.state,
-        data: result.data.filter((data: any) => data?.results),
-      };
-    }
+    const dataResult = result.data;
 
     if (debug) {
       const limitedData: ApiQueryExecutionResponse = {
@@ -199,7 +193,7 @@ const postQueryEdgeDatabase = async (
           ...data,
           results: {
             ...data.results,
-            rows: limitArraySize(data.results.rows, 10),
+            rows: limitArraySize(data.results?.rows, 10),
           },
         })),
       };
@@ -207,7 +201,7 @@ const postQueryEdgeDatabase = async (
     }
     return {
       state: result.state,
-      data: result.data,
+      data: dataResult,
     };
   } catch (error: any) {
     if (debug) console.error('Error querying EdgeDB:', error);
@@ -218,14 +212,14 @@ const postQueryEdgeDatabase = async (
 };
 
 /**
- * Retrieves a list of Edge Databases.
+ * Retrieves a list of Databases.
  */
-const getEdgeDatabases = async (
+const getDatabases = async (
   token: string,
   params?: Partial<AzionDatabaseCollectionOptions>,
   debug?: boolean,
   env: AzionEnvironment = 'production',
-): Promise<ApiListDatabasesResponse> => {
+): Promise<ApiDatabaseListResponse> => {
   try {
     const baseUrl = getBaseUrl(env);
     const url = new URL(baseUrl);
@@ -243,12 +237,13 @@ const getEdgeDatabases = async (
 
     const data = await fetchWithErrorHandling(url.toString(), options, debug);
 
-    if (!data.results) {
-      data.error = handleApiError(['detail'], data, 'get databases');
+    if (data.errors) {
       return {
-        error: data.error ?? JSON.stringify(data),
+        error: handleApiError([], data, 'get databases'),
       };
     }
+
+    const dataResult = data.results;
 
     if (debug) {
       const limitedData = {
@@ -259,25 +254,56 @@ const getEdgeDatabases = async (
     }
 
     return {
-      links: data?.links,
       count: data.count,
-      results: data.results.map((result: any) => ({
-        clientId: result.client_id,
-        createdAt: result.created_at,
-        deletedAt: result.deleted_at,
-        id: result.id,
-        isActive: result.is_active,
-        name: result.name,
-        status: result.status,
-        updatedAt: result.updated_at,
-      })),
+      results: dataResult,
     };
-  } catch (error: any) {
+  } catch (error) {
     if (debug) console.error('Error getting all EdgeDBs:', error);
     return {
-      error: { message: error.toString(), operation: 'get databases' },
+      error: { message: (error as Error).message, operation: 'get databases' },
     };
   }
 };
 
-export { deleteEdgeDatabase, getEdgeDatabases, postEdgeDatabase, postQueryEdgeDatabase };
+/**
+ * Retrieve of Databases.
+ */
+const retrieveDatabase = async (
+  token: string,
+  id: number,
+  debug?: boolean,
+  env: AzionEnvironment = 'production',
+): Promise<ApiRetrieveDatabaseResponse> => {
+  try {
+    const baseUrl = getBaseUrl(env);
+    const url = new URL(baseUrl);
+
+    url.pathname += `/${id}`;
+
+    const headers = buildHeaders(token);
+    const options = buildFetchOptions('GET', headers);
+
+    const result = await fetchWithErrorHandling(url.toString(), options, debug);
+
+    if (result.errors) {
+      return {
+        error: handleApiError([], result, 'retrieve database'),
+      };
+    }
+
+    if (debug) {
+      console.log('Response Databases:', JSON.stringify(result));
+    }
+
+    return {
+      data: result.data,
+    };
+  } catch (error) {
+    if (debug) console.error('Error getting all EdgeDBs:', error);
+    return {
+      error: { message: (error as Error).message, operation: 'get databases' },
+    };
+  }
+};
+
+export { deleteDatabase, getDatabases, postDatabase, postQueryDatabase, retrieveDatabase };

--- a/packages/sql/src/services/api/types.ts
+++ b/packages/sql/src/services/api/types.ts
@@ -1,54 +1,54 @@
-/* eslint-disable no-unused-vars */
-export interface ApiDatabaseResponse {
+export type ApiDatabase = {
   id: number;
   name: string;
-  clientId: string;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string | null;
-  isActive: boolean;
-}
-
-export interface ApiListDatabasesResponse {
-  count?: number;
-  links?: {
-    first: string | null;
-    last: string | null;
-    next: string | null;
-    prev: string | null;
-  };
-  results?: ApiDatabaseResponse[];
-  error?: ApiError;
-}
+  status: 'creating' | 'created' | 'deleting';
+  active: boolean;
+  last_modified: string;
+  last_editor: string | null;
+  product_version: string;
+};
 
 export type ApiError = {
   message: string;
   operation: string;
+  metadata?: Record<string, unknown>;
 };
 
-export interface ApiQueryExecutionResponse {
+export type ApiDatabaseListResponse = {
+  count?: number;
+  results?: ApiDatabase[];
+  error?: ApiError;
+};
+
+export type ApiRetrieveDatabaseResponse = {
+  data?: ApiDatabase;
+  error?: ApiError;
+};
+
+export type ApiCreateDatabaseResponse = {
+  state?: 'executed' | 'pending' | 'failed';
+  data?: ApiDatabase;
+  error?: ApiError;
+};
+
+export type ApiDeleteDatabaseResponse = {
+  state?: 'executed' | 'pending';
+  error?: ApiError;
+};
+
+export type ApiQueryExecutionData = {
+  columns: string[];
+  rows: (number | string)[][];
+  rows_read?: number;
+  rows_written?: number;
+  query_duration_ms?: number;
+};
+
+export type ApiQueryExecutionResponse = {
   state?: 'executed' | 'pending' | 'failed';
   data?: {
-    results: {
-      columns: string[];
-      rows: (number | string)[][];
-      rows_read?: number;
-      rows_written?: number;
-      query_duration_ms?: number;
-    };
+    results: ApiQueryExecutionData;
+    error?: string;
   }[];
   error?: ApiError;
-}
-
-export interface ApiCreateDatabaseResponse {
-  state?: 'executed' | 'pending' | 'failed';
-  data?: ApiDatabaseResponse;
-  error?: ApiError;
-}
-
-export interface ApiDeleteDatabaseResponse {
-  state?: 'executed' | 'pending';
-  data?: { id: number };
-  error?: ApiError;
-}
+};

--- a/packages/sql/src/services/index.ts
+++ b/packages/sql/src/services/index.ts
@@ -1,7 +1,7 @@
 import { AzionClientOptions, AzionDatabaseQueryResponse, AzionDatabaseResponse, QueryResult } from '../types';
 import { limitArraySize } from '../utils';
 import { toObjectQueryExecutionResponse } from '../utils/mappers/to-object';
-import { getEdgeDatabases, postQueryEdgeDatabase } from './api/index';
+import { getDatabases, postQueryDatabase } from './api/index';
 import { InternalAzionSql } from './runtime/index';
 
 // Api Query Internal Method to execute a query on a database
@@ -11,16 +11,14 @@ export const apiQuery = async (
   statements: string[],
   options?: AzionClientOptions,
 ): Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>> => {
-  const databaseResponse = await getEdgeDatabases(token, { search: name }, options?.debug);
+  const databaseResponse = await getDatabases(token, { search: name, page_size: 1 }, options?.debug, options?.env);
 
   if (databaseResponse?.error) {
-    return {
-      error: databaseResponse?.error,
-    };
+    return { error: databaseResponse.error };
   }
 
-  const databases = databaseResponse?.results;
-  if (!databases || databases.length === 0) {
+  const database = databaseResponse?.results?.[0];
+  if (!database?.name) {
     return {
       error: {
         message: `Database ${name} not found`,
@@ -29,43 +27,67 @@ export const apiQuery = async (
     };
   }
 
-  const database = databases[0];
-  if (!database?.id) {
+  // call the postQueryDatabase function to execute the query
+  const { state, data, error } = await postQueryDatabase(token, database.id, statements, options?.debug, options?.env);
+
+  if (error) {
     return {
       error: {
-        message: `Database ${name} not found`,
+        message: error.message || 'Error executing query',
         operation: 'apiQuery',
       },
     };
   }
-
-  const { state, data, error } = await postQueryEdgeDatabase(token, database.id, statements, options?.debug);
-
-  let resultStatements: AzionDatabaseQueryResponse = {
-    state: 'executed',
-    results: undefined,
-    toObject: () => null,
-  };
-
-  const isData = data && data.length > 0;
-  if (isData) {
-    resultStatements = {
-      state,
-      results: data.map((result, index) => {
-        return {
-          statement: statements[index]?.split(' ')[0],
-          columns:
-            result?.results?.columns && result?.results?.columns.length > 0 ? result?.results?.columns : undefined,
-          rows: result?.results?.rows && result?.results?.rows.length > 0 ? result?.results?.rows : undefined,
-        };
+  const resultsWithStatements = data?.map((result, index) => {
+    return {
+      statement: statements[index]?.split(' ')[0],
+      columns: result?.results?.columns && result?.results?.columns.length > 0 ? result?.results?.columns : undefined,
+      rows: result?.results?.rows && result?.results?.rows.length > 0 ? result?.results?.rows : undefined,
+      error: result?.error || undefined,
+    };
+  });
+  if (options?.debug && resultsWithStatements) {
+    // limit the size of the array to 10
+    const limitedData = resultsWithStatements.map((data) => {
+      return {
+        ...data,
+        rows: limitArraySize(data?.rows || [], 10),
+      };
+    });
+    console.log(
+      'Response Query:',
+      JSON.stringify({
+        state,
+        results: limitedData,
+        toObject: () => null,
       }),
-      toObject: () => toObjectQueryExecutionResponse(resultStatements),
-    };
+    );
   }
+
+  // Check if there are any errors in the results
+  const someErrorInStatements =
+    resultsWithStatements && resultsWithStatements.filter((result) => result?.error !== undefined);
+
   return {
-    data: isData ? resultStatements : undefined,
-    error,
-  };
+    data: {
+      state: state as AzionDatabaseQueryResponse['state'],
+      results: resultsWithStatements,
+      toObject: () =>
+        toObjectQueryExecutionResponse({
+          results: resultsWithStatements,
+          state: state as AzionDatabaseQueryResponse['state'],
+          toObject: () => null,
+        }),
+    },
+    // If there are, return an error response
+    error:
+      someErrorInStatements && someErrorInStatements.length > 0
+        ? {
+            message: someErrorInStatements.map((result) => result?.error || 'Error executing query').join(', '),
+            operation: 'apiQuery',
+          }
+        : undefined,
+  } as AzionDatabaseResponse<AzionDatabaseQueryResponse>;
 };
 
 // Runtime Query Internal Method to execute a query on a database
@@ -81,6 +103,7 @@ export const runtimeQuery = async (
     const internalSql = new InternalAzionSql();
     const internalResult = await internalSql.query(name, statements, options);
     const resultStatements: AzionDatabaseQueryResponse = {
+      state: 'executed-runtime',
       results: [],
       toObject: () => null,
     };

--- a/packages/sql/src/types.ts
+++ b/packages/sql/src/types.ts
@@ -1,22 +1,22 @@
 import { JsonObjectQueryExecutionResponse } from './utils/mappers/to-object';
 
-export type AzionDatabaseResponse<T> = {
-  data?: T;
-  error?: {
-    message: string;
-    operation: string;
-  };
-};
-
-/* eslint-disable no-unused-vars */
-export interface AzionDatabase {
+export type Database = {
   id: number;
   name: string;
-  clientId: string;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string | null;
+  status: 'creating' | 'created' | 'deleting';
+  active: boolean;
+  lastModified: string;
+  lastEditor: string | null;
+  productVersion: string;
+};
+
+export type AzionSQLError = {
+  message: string;
+  operation: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type AzionDatabase = Database & {
   /**
    * Executes a query or multiple queries on the database.
    *
@@ -63,25 +63,46 @@ export interface AzionDatabase {
    * const { data: tables, error } = await database.getTables({ debug: true });
    */
   getTables: (options?: AzionClientOptions) => Promise<AzionDatabaseResponse<AzionDatabaseQueryResponse>>;
-}
-
-export type AzionQueryParams = string | number | boolean | null;
-
-export type AzionQueryExecutionParams = {
-  statements: string[];
-  params?: (AzionQueryParams | Record<string, AzionQueryParams>)[];
 };
 
 export type QueryResult = {
   columns?: string[];
-  rows?: (number | string)[][];
+  rows?: (string | number)[][];
   statement?: string;
+  error?: string;
+};
+
+export type ToObjectQueryExecution = {
+  data: Array<{
+    statement?: string;
+    rows: Record<string, string | number>[];
+  }>;
 };
 
 export type AzionDatabaseQueryResponse = {
-  state?: 'pending' | 'failed' | 'executed' | 'executed-runtime';
+  state: 'pending' | 'failed' | 'executed' | 'executed-runtime';
   results?: QueryResult[];
   toObject: () => JsonObjectQueryExecutionResponse | null;
+};
+
+export type AzionDatabaseResponse<T> = {
+  data?: T;
+  error?: AzionSQLError;
+};
+
+export type AzionQueryParams =
+  | string
+  | number
+  | boolean
+  | null
+  | {
+      type: string;
+      value: string | number | boolean | null;
+    };
+
+export type AzionQueryExecutionParams = {
+  statements: string[];
+  params: Array<AzionQueryParams | Record<string, AzionQueryParams>>;
 };
 
 export type AzionDatabaseExecutionResponse = AzionDatabaseQueryResponse;
@@ -100,7 +121,6 @@ export type AzionDatabaseCollections = {
 
 export type AzionDatabaseDeleteResponse = {
   state: 'pending' | 'failed' | 'executed';
-  id: number;
 };
 
 export interface AzionSQLClient {

--- a/packages/sql/src/utils/mappers/to-object.ts
+++ b/packages/sql/src/utils/mappers/to-object.ts
@@ -8,7 +8,7 @@ export type JsonObjectQueryExecutionResponse = {
   }[];
 };
 
-export const toObjectQueryExecutionResponse = ({ results }: AzionDatabaseQueryResponse) => {
+export const toObjectQueryExecutionResponse = ({ state, results }: AzionDatabaseQueryResponse) => {
   let transformedData: any = [];
   if (results instanceof Array) {
     if (results.length === 0) {
@@ -36,6 +36,7 @@ export const toObjectQueryExecutionResponse = ({ results }: AzionDatabaseQueryRe
     });
   }
   return {
+    state: state as AzionDatabaseQueryResponse['state'],
     results: transformedData,
   };
 };

--- a/packages/sql/src/utils/validations/error-response.ts
+++ b/packages/sql/src/utils/validations/error-response.ts
@@ -1,0 +1,9 @@
+export function handleUnknownError<T>(error: unknown, operation: string): T {
+  console.error('An unexpected error occurred:', error);
+  return {
+    error: {
+      message: 'An unexpected error occurred during the operation',
+      operation,
+    },
+  } as T;
+}


### PR DESCRIPTION
This pull request refactors the Azion SQL client to remove references to "Edge SQL," update API method names, and improve the handling and transformation of database objects and responses. The changes also update documentation and examples to match the new API structure and improve error handling and response consistency.

### API Refactoring and Naming

* Renamed API service and method imports in `src/index.ts` from `deleteEdgeDatabase`, `getEdgeDatabases`, and `postEdgeDatabase` to `deleteDatabase`, `getDatabases`, and `postDatabase` for consistency with the new API naming.
* Updated client method calls to use the new API methods and adjusted configuration handling to use `config?.options` instead of `config` directly.

### Database Object Transformation

* Introduced `AzionDatabaseTransform.parse` to transform API database objects into the internal format, ensuring consistent mapping of fields like `active`, `lastModified`, and `productVersion`.
* Updated the database response object structure in documentation and code, replacing fields such as `clientId`, `createdAt`, and `updatedAt` with new fields like `active`, `lastModified`, and `lastEditor`.

### Error Handling and Response Consistency

* Improved error handling in database methods (`createDatabaseMethod`, `getDatabaseMethod`, `getDatabasesMethod`) by wrapping API calls in try-catch blocks and using a centralized `handleUnknownError` function for unknown errors. [[1]](diffhunk://#diff-cb0469ebcd7c7956b77984e84f252493f4a7bbddb760497164c05b1192ab3d4fR83-R91) [[2]](diffhunk://#diff-cb0469ebcd7c7956b77984e84f252493f4a7bbddb760497164c05b1192ab3d4fR149-R190) [[3]](diffhunk://#diff-cb0469ebcd7c7956b77984e84f252493f4a7bbddb760497164c05b1192ab3d4fL193-R228)
* Updated response handling to check for errors in API responses and return consistent error objects or empty collections when no results are found. [[1]](diffhunk://#diff-cb0469ebcd7c7956b77984e84f252493f4a7bbddb760497164c05b1192ab3d4fL193-R228) [[2]](diffhunk://#diff-cb0469ebcd7c7956b77984e84f252493f4a7bbddb760497164c05b1192ab3d4fL207-R240)

### Documentation and Example Updates

* Updated README files and code comments to remove references to "Edge SQL" and reflect the new API structure and field names. [[1]](diffhunk://#diff-c03c1c4d1b620b7d074f18e2cf86b00f0f727d94a2d2b403f3369ec8054339f0L1-R3) [[2]](diffhunk://#diff-c03c1c4d1b620b7d074f18e2cf86b00f0f727d94a2d2b403f3369ec8054339f0L465-R465) [[3]](diffhunk://#diff-cb0469ebcd7c7956b77984e84f252493f4a7bbddb760497164c05b1192ab3d4fL474-R496)
* Updated code examples in documentation to use the new response structure, including accessing `results.rows` instead of `data.rows`, and referencing new object fields. [[1]](diffhunk://#diff-c21d2ad60baddf845d9f54e1eba1a9d2d56672f4ef1790db830fa9ada060c143L144-R144) [[2]](diffhunk://#diff-c03c1c4d1b620b7d074f18e2cf86b00f0f727d94a2d2b403f3369ec8054339f0L358-R358) [[3]](diffhunk://#diff-c03c1c4d1b620b7d074f18e2cf86b00f0f727d94a2d2b403f3369ec8054339f0L432-R432)

### Testing Configuration

* Limited Jest test concurrency to a single worker for improved reliability in the test script.