### PR TITLE
fix: move Storage class export to bottom of file for better organization

### DIFF
--- a/packages/bundler/src/polyfills/azion/storage/storage.polyfills.js
+++ b/packages/bundler/src/polyfills/azion/storage/storage.polyfills.js
@@ -16,7 +16,7 @@ const PRIVATE_CONSTRUCTOR = Symbol('PRIVATE_CONSTRUCTOR');
  * Class representing a storage container.
  * @class
  */
-export default class Storage {
+class Storage {
   #bucketName;
 
   /**
@@ -200,3 +200,5 @@ export class StorageObjectList {
 
 globalThis.Azion = globalThis.Azion || {};
 globalThis.Azion.Storage = Storage;
+
+export default Storage;


### PR DESCRIPTION
This pull request updates the way the `Storage` class is exported in `storage.polyfills.js` to improve clarity and consistency. The main change is switching from a default export at the class declaration to an explicit default export at the end of the file.

Export improvements:

* Changed the `Storage` class declaration from `export default class Storage` to a plain `class Storage`, and moved the default export to the end of the file with `export default Storage;` [[1]](diffhunk://#diff-46dc1fbd1c625240135d0f56b0838bc09672f625b2b86d76a58f15a293598f1bL19-R19) [[2]](diffhunk://#diff-46dc1fbd1c625240135d0f56b0838bc09672f625b2b86d76a58f15a293598f1bR203-R204)