### PR TITLE
feat(bundler-telemetry): add telemetry package for build performance

### DIFF
--- a/.changeset/grumpy-llamas-build.md
+++ b/.changeset/grumpy-llamas-build.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/bundler-telemetry': major
+---
+
+feat: add pck bundler-telemetry

--- a/packages/bundler-telemetry/README.md
+++ b/packages/bundler-telemetry/README.md
@@ -1,0 +1,247 @@
+# @aziontech/bundler-telemetry
+
+> Telemetry system for measuring and reporting build performance in Azion Bundler
+
+## Installation
+
+```bash
+npm install @aziontech/bundler-telemetry
+# or
+pnpm add @aziontech/bundler-telemetry
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { TelemetryCollector } from '@aziontech/bundler-telemetry';
+
+const telemetry = new TelemetryCollector(
+  {
+    enabled: true,
+    outputFormat: 'both',
+    outputPath: '.edge/telemetry-report.json',
+  },
+  {
+    bundlerVersion: '7.2.0',
+    preset: 'nextjs',
+    bundler: 'esbuild',
+    production: true,
+    entry: './src/main.ts',
+  },
+);
+
+// Measure async operations
+await telemetry.measureAsync('dependencies-check', async () => {
+  await checkDependencies();
+});
+
+await telemetry.measureAsync('preset-resolution', async () => {
+  return await resolvePreset(config.build?.preset);
+});
+
+// Or use manual span management
+const buildSpanId = telemetry.startSpan('core-build', { bundler: 'esbuild' });
+// ... perform build
+telemetry.endSpan(buildSpanId);
+
+// Generate output
+telemetry.printToConsole();
+await telemetry.saveReport();
+```
+
+### Output
+
+When `outputFormat` is set to `'console'` or `'both'`, telemetry will display real-time progress:
+
+```
+⚡ Azion Bundler v7.2.0
+
+📦 Build Configuration
+   Preset: nextjs
+   Bundler: esbuild
+   Mode: production
+
+⚙️  Starting build pipeline...
+
+✓ Dependencies Check        45ms
+✓ Preset Resolution         120ms
+✓ Build Config Setup         80ms
+✓ Environment Setup          30ms
+✓ Prebuild                  250ms
+✓ Handler Resolution         15ms
+✓ Worker Setup              100ms
+✓ Core Build                1.5s
+✓ Postbuild                 180ms
+✓ Storage Setup              60ms
+✓ Bindings Setup             45ms
+✓ Env Vars Copy              10ms
+
+📊 Build Summary
+   Status: Success
+   Total Duration: 2.4s
+   Memory Delta: +150MB heap, +200MB RSS
+   Bundle Size: 512KB
+   Modules: 150
+
+📄 Telemetry report saved to .edge/telemetry-report.json
+```
+
+### JSON Report
+
+The JSON report is saved to the specified `outputPath`:
+
+```json
+{
+  "bundlerVersion": "7.2.0",
+  "nodeVersion": "v18.20.0",
+  "platform": "darwin",
+  "arch": "x64",
+  "timestamp": "2024-04-08T14:30:00.000Z",
+  "preset": "nextjs",
+  "bundler": "esbuild",
+  "production": true,
+  "entry": ["./src/main.ts"],
+  "systemInfo": {
+    "cpus": 8,
+    "totalMemory": 16384,
+    "freeMemory": 8192,
+    "platform": "darwin",
+    "arch": "x64"
+  },
+  "spans": [
+    {
+      "id": "span_123",
+      "name": "core-build",
+      "startTime": 1000,
+      "endTime": 2500,
+      "duration": 1500,
+      "status": "completed",
+      "attributes": {}
+    }
+  ],
+  "summary": {
+    "totalDuration": 2400,
+    "totalMemoryDelta": {
+      "heapUsed": 157286400,
+      "rss": 209715200
+    },
+    "bundleSize": 524288,
+    "modulesCount": 150,
+    "success": true
+  }
+}
+```
+
+## API Reference
+
+### `TelemetryCollector`
+
+Main class for collecting telemetry data.
+
+#### Constructor
+
+```typescript
+new TelemetryCollector(config: TelemetryConfig, metadata: TelemetryBuildMetadata)
+```
+
+#### Methods
+
+| Method                                    | Description                    |
+| ----------------------------------------- | ------------------------------ |
+| `startSpan(name, attributes?, parentId?)` | Start a new span               |
+| `endSpan(spanId, error?)`                 | End a span                     |
+| `measureAsync<T>(name, fn, attributes?)`  | Measure async function         |
+| `measureSync<T>(name, fn, attributes?)`   | Measure sync function          |
+| `markFailed(error)`                       | Mark build as failed           |
+| `setSpanAttributes(spanId, attributes)`   | Set additional span attributes |
+| `getSpan(spanId)`                         | Get span by ID                 |
+| `getAllSpans()`                           | Get all spans                  |
+| `getChildSpans(parentId)`                 | Get child spans                |
+| `finalize()`                              | Generate final report          |
+| `printToConsole()`                        | Print summary to console       |
+| `saveReport(path?)`                       | Save report to JSON file       |
+| `getSystemInfo()`                         | Get system information         |
+| `getTotalDuration()`                      | Get total build duration       |
+| `getMemoryDelta()`                        | Get memory delta               |
+
+### Types
+
+```typescript
+interface TelemetryConfig {
+  enabled: boolean;
+  outputFormat: 'console' | 'json' | 'both';
+  outputPath: string;
+  openTelemetry?: {
+    enabled: boolean;
+    endpoint?: string;
+    serviceName: string;
+  };
+}
+
+interface TelemetrySpan {
+  id: string;
+  name: string;
+  parentId?: string;
+  startTime: number;
+  endTime?: number;
+  duration?: number;
+  attributes: Record<string, unknown>;
+  memoryBefore?: NodeJS.MemoryUsage;
+  memoryAfter?: NodeJS.MemoryUsage;
+  status: 'running' | 'completed' | 'error';
+  errorMessage?: string;
+}
+
+interface TelemetryReport {
+  bundlerVersion: string;
+  nodeVersion: string;
+  platform: string;
+  arch: string;
+  timestamp: string;
+  preset: string;
+  bundler: 'esbuild' | 'webpack';
+  production: boolean;
+  entry: string | string[];
+  systemInfo: TelemetrySystemInfo;
+  spans: TelemetrySpan[];
+  plugins?: TelemetryPluginMetrics[];
+  summary: {
+    totalDuration: number;
+    totalMemoryDelta: { heapUsed: number; rss: number };
+    bundleSize?: number;
+    modulesCount?: number;
+    success: boolean;
+    errorMessage?: string;
+  };
+}
+```
+
+### Utility Functions
+
+```typescript
+// Console formatters
+formatHeader(bundlerVersion: string): string
+formatBuildConfig(metadata: TelemetryBuildMetadata): string
+formatPhaseStart(span: TelemetrySpan): string
+formatPhaseComplete(span: TelemetrySpan): string
+formatPhaseError(span: TelemetrySpan): string
+formatSummary(report: TelemetryReport): string
+formatDuration(ms: number): string
+formatBytes(bytes: number): string
+
+// Report utilities
+reportToJSON(report: TelemetryReport, options?: ReportOptions): string
+createSummaryReport(report: TelemetryReport): object
+compareReports(report1: TelemetryReport, report2: TelemetryReport): object
+extractPluginMetrics(spans: TelemetrySpan[]): TelemetryPluginMetrics[]
+```
+
+## Environment Variables
+
+- `AZION_TELEMETRY=false` - Disable telemetry collection
+
+## License
+
+MIT

--- a/packages/bundler-telemetry/jest.config.ts
+++ b/packages/bundler-telemetry/jest.config.ts
@@ -1,0 +1,18 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+import type { Config } from 'jest';
+
+const config: Config = {
+  displayName: 'Bundler Telemetry',
+  clearMocks: true,
+  coverageProvider: 'v8',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+};
+
+export default config;

--- a/packages/bundler-telemetry/package.json
+++ b/packages/bundler-telemetry/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@aziontech/bundler-telemetry",
+  "version": "0.0.0",
+  "description": "Telemetry system for measuring and reporting build performance in Azion Bundler",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "compile": "vite build",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
+    "prettier": "prettier --write .",
+    "test": "jest --clearCache && jest",
+    "test:watch": "jest -c jest.config.js . --watch",
+    "test:coverage": "jest --clearCache && jest -c jest.config.js . --coverage"
+  },
+  "author": "aziontech",
+  "license": "MIT",
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "devDependencies": {
+    "@aziontech/vite-config": "workspace:*",
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^22.13.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.5",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/packages/bundler-telemetry/src/collector.ts
+++ b/packages/bundler-telemetry/src/collector.ts
@@ -1,0 +1,312 @@
+/**
+ * Telemetry Collector - Main class for collecting build telemetry
+ */
+
+import * as os from 'os';
+
+import { formatSummary } from './console';
+import { saveHTMLReport } from './html-reporter';
+import { generateReport, saveReport } from './reporter';
+import type {
+  TelemetryBuildMetadata,
+  TelemetryConfig,
+  TelemetryReport,
+  TelemetrySpan,
+  TelemetrySystemInfo,
+} from './types';
+
+/**
+ * Main telemetry collector class for tracking build performance
+ */
+export class TelemetryCollector {
+  private config: TelemetryConfig;
+  private spans: Map<string, TelemetrySpan> = new Map();
+  private rootSpanId: string | null = null;
+  private metadata: TelemetryBuildMetadata;
+  private startTime: number;
+  private startMemory: NodeJS.MemoryUsage;
+  private endMemory: NodeJS.MemoryUsage | null = null;
+  private buildSuccess: boolean = true;
+  private errorMessage: string | undefined;
+
+  /**
+   * Create a new TelemetryCollector instance
+   */
+  constructor(config: TelemetryConfig, metadata: TelemetryBuildMetadata) {
+    this.config = config;
+    this.metadata = metadata;
+    this.startTime = performance.now();
+    this.startMemory = process.memoryUsage();
+    // Note: Header and build config logging is handled by the caller (build.ts)
+    // to avoid duplication with runPhaseWithTelemetry
+  }
+
+  /**
+   * Start a new span for tracking a phase or operation
+   * @param name - Name of the span
+   * @param attributes - Optional attributes/metadata for the span
+   * @param parentId - Optional parent span ID for nested spans
+   * @returns The ID of the created span
+   */
+  startSpan(name: string, attributes?: Record<string, unknown>, parentId?: string): string {
+    if (!this.config.enabled) {
+      return '';
+    }
+
+    const id = this.generateSpanId();
+    const span: TelemetrySpan = {
+      id,
+      name,
+      parentId: parentId ?? this.rootSpanId ?? undefined,
+      startTime: performance.now(),
+      memoryBefore: process.memoryUsage(),
+      attributes: attributes ?? {},
+      status: 'running',
+    };
+
+    if (!this.rootSpanId) {
+      this.rootSpanId = id;
+    }
+
+    this.spans.set(id, span);
+    return id;
+  }
+
+  /**
+   * End a span and record its final state
+   * @param spanId - The ID of the span to end
+   * @param error - Optional error message if the span failed
+   */
+  endSpan(spanId: string, error?: string): void {
+    if (!this.config.enabled || !spanId) {
+      return;
+    }
+
+    const span = this.spans.get(spanId);
+    if (!span) {
+      return;
+    }
+
+    span.endTime = performance.now();
+    span.duration = span.endTime - span.startTime;
+    span.memoryAfter = process.memoryUsage();
+    span.status = error ? 'error' : 'completed';
+    span.errorMessage = error;
+    // Note: Console logging is handled by runPhaseWithTelemetry to avoid duplication
+  }
+
+  /**
+   * Measure an async function execution
+   * @param name - Name for the span
+   * @param fn - Async function to measure
+   * @param attributes - Optional attributes for the span
+   * @returns The result of the async function
+   */
+  async measureAsync<T>(name: string, fn: () => Promise<T>, attributes?: Record<string, unknown>): Promise<T> {
+    if (!this.config.enabled) {
+      return fn();
+    }
+
+    const spanId = this.startSpan(name, attributes);
+    try {
+      const result = await fn();
+      this.endSpan(spanId);
+      return result;
+    } catch (error) {
+      this.endSpan(spanId, error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+  }
+
+  /**
+   * Measure a sync function execution
+   * @param name - Name for the span
+   * @param fn - Sync function to measure
+   * @param attributes - Optional attributes for the span
+   * @returns The result of the sync function
+   */
+  measureSync<T>(name: string, fn: () => T, attributes?: Record<string, unknown>): T {
+    if (!this.config.enabled) {
+      return fn();
+    }
+
+    const spanId = this.startSpan(name, attributes);
+    try {
+      const result = fn();
+      this.endSpan(spanId);
+      return result;
+    } catch (error) {
+      this.endSpan(spanId, error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+  }
+
+  /**
+   * Mark the build as failed with an error message
+   * @param error - Error message
+   */
+  markFailed(error: string): void {
+    this.buildSuccess = false;
+    this.errorMessage = error;
+  }
+
+  /**
+   * Set additional attributes on an existing span
+   * @param spanId - The span ID
+   * @param attributes - Attributes to merge
+   */
+  setSpanAttributes(spanId: string, attributes: Record<string, unknown>): void {
+    if (!this.config.enabled || !spanId) {
+      return;
+    }
+
+    const span = this.spans.get(spanId);
+    if (span) {
+      span.attributes = { ...span.attributes, ...attributes };
+    }
+  }
+
+  /**
+   * Get the current span by ID
+   * @param spanId - The span ID
+   * @returns The span or undefined
+   */
+  getSpan(spanId: string): TelemetrySpan | undefined {
+    return this.spans.get(spanId);
+  }
+
+  /**
+   * Get all spans
+   * @returns Array of all spans
+   */
+  getAllSpans(): TelemetrySpan[] {
+    return Array.from(this.spans.values());
+  }
+
+  /**
+   * Get spans that have a specific parent
+   * @param parentId - Parent span ID
+   * @returns Array of child spans
+   */
+  getChildSpans(parentId: string): TelemetrySpan[] {
+    return this.getAllSpans().filter((span) => span.parentId === parentId);
+  }
+
+  /**
+   * Finalize the telemetry collection and generate report
+   */
+  finalize(): TelemetryReport {
+    this.endMemory = process.memoryUsage();
+    const report = generateReport(this, this.metadata);
+    return report;
+  }
+
+  /**
+   * Print the telemetry summary to console
+   */
+  printToConsole(): void {
+    if (!this.config.enabled || this.config.outputFormat === 'json') {
+      return;
+    }
+
+    const report = this.finalize();
+    console.log(formatSummary(report));
+  }
+
+  /**
+   * Save the telemetry report to a JSON file and optionally HTML
+   * @param jsonPath - Optional path override for JSON (uses config path if not provided)
+   * @param htmlPath - Optional path override for HTML (uses config htmlOutputPath if not provided)
+   */
+  async saveReport(jsonPath?: string, htmlPath?: string): Promise<void> {
+    if (!this.config.enabled || this.config.outputFormat === 'console') {
+      return;
+    }
+
+    const report = this.finalize();
+    const outputJsonPath = jsonPath ?? this.config.outputPath;
+
+    // Save JSON report
+    await saveReport(report, outputJsonPath);
+
+    // Determine HTML path
+    const outputHtmlPath = htmlPath ?? this.config.htmlOutputPath ?? outputJsonPath.replace(/\.json$/, '.html');
+
+    // Save HTML report
+    if (this.config.outputFormat === 'html' || this.config.outputFormat === 'both') {
+      await saveHTMLReport(report, outputHtmlPath);
+      console.log(`📄 Telemetry reports saved:\n   JSON: ${outputJsonPath}\n   HTML: ${outputHtmlPath}\n`);
+    } else if (this.config.outputFormat === 'json') {
+      console.log(`📄 Telemetry report saved to ${outputJsonPath}\n`);
+    }
+  }
+
+  /**
+   * Get the system information
+   */
+  getSystemInfo(): TelemetrySystemInfo {
+    try {
+      return {
+        cpus: os.cpus?.()?.length ?? 0,
+        totalMemory: os.totalmem?.() ?? 0,
+        freeMemory: os.freemem?.() ?? 0,
+        platform: os.platform?.() ?? 'unknown',
+        arch: os.arch?.() ?? 'unknown',
+      };
+    } catch {
+      return {
+        cpus: 0,
+        totalMemory: 0,
+        freeMemory: 0,
+        platform: 'unknown',
+        arch: 'unknown',
+      };
+    }
+  }
+
+  /**
+   * Get the start time of the build
+   */
+  getStartTime(): number {
+    return this.startTime;
+  }
+
+  /**
+   * Get the total duration of the build
+   */
+  getTotalDuration(): number {
+    return performance.now() - this.startTime;
+  }
+
+  /**
+   * Get the memory delta (current - start)
+   */
+  getMemoryDelta(): { heapUsed: number; rss: number } {
+    const currentMemory = this.endMemory ?? process.memoryUsage();
+    return {
+      heapUsed: currentMemory.heapUsed - this.startMemory.heapUsed,
+      rss: currentMemory.rss - this.startMemory.rss,
+    };
+  }
+
+  /**
+   * Get the build success status
+   */
+  getBuildSuccess(): boolean {
+    return this.buildSuccess;
+  }
+
+  /**
+   * Get the error message if build failed
+   */
+  getErrorMessage(): string | undefined {
+    return this.errorMessage;
+  }
+
+  /**
+   * Generate a unique span ID
+   */
+  private generateSpanId(): string {
+    return `span_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+  }
+}

--- a/packages/bundler-telemetry/src/console.ts
+++ b/packages/bundler-telemetry/src/console.ts
@@ -1,0 +1,217 @@
+/**
+ * Console output formatters for telemetry display
+ */
+
+import type { ConsoleFormatters, TelemetryBuildMetadata, TelemetryReport, TelemetrySpan } from './types';
+
+/**
+ * ANSI color codes for terminal output
+ */
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m',
+};
+
+/**
+ * Symbols for visual indicators
+ */
+const symbols = {
+  check: '✓',
+  hourglass: '⏳',
+  warning: '⚠️',
+  error: '❌',
+  info: 'ℹ️',
+  package: '📦',
+  chart: '📊',
+  gear: '⚙️',
+  lightning: '⚡',
+};
+
+/**
+ * Format a duration in milliseconds to a human-readable string
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  if (ms < 60000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.round((ms % 60000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Format bytes to human-readable string
+ */
+export function formatBytes(bytes: number): string {
+  if (Math.abs(bytes) < 1024) {
+    return `${bytes}B`;
+  }
+  if (Math.abs(bytes) < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/**
+ * Format the header/banner for the build
+ */
+export function formatHeader(bundlerVersion: string): string {
+  return `
+${colors.bright}${colors.magenta}${symbols.lightning} Azion Bundler ${colors.cyan}v${bundlerVersion}${colors.reset}`;
+}
+
+/**
+ * Format the build configuration display
+ */
+export function formatBuildConfig(metadata: TelemetryBuildMetadata): string {
+  const mode = metadata.production
+    ? `${colors.red}production${colors.reset}`
+    : `${colors.cyan}development${colors.reset}`;
+  return `
+${colors.bright}${symbols.package} Build Configuration${colors.reset}
+   Preset: ${colors.cyan}${metadata.preset}${colors.reset}
+   Bundler: ${colors.cyan}${metadata.bundler}${colors.reset}
+   Mode: ${mode}`;
+}
+
+/**
+ * Format a span when it starts (for real-time display)
+ */
+export function formatPhaseStart(span: TelemetrySpan): string {
+  return `${colors.dim}${symbols.hourglass} ${span.name}...${colors.reset}`;
+}
+
+/**
+ * Format a span when it completes
+ */
+export function formatPhaseComplete(span: TelemetrySpan): string {
+  if (span.status === 'error') {
+    return `${colors.red}${symbols.error} ${span.name}${colors.reset} ${colors.red}FAILED: ${span.errorMessage}${colors.reset}`;
+  }
+
+  const duration = span.duration ? formatDuration(span.duration) : 'N/A';
+  let warning = '';
+
+  // Show warning if this phase took more than 1 second and represents > 30% of total build
+  if (span.duration && span.duration > 1000) {
+    warning = ` ${colors.yellow}${symbols.warning}${colors.reset} ${colors.dim}(${colors.yellow}slow phase${colors.dim})${colors.reset}`;
+  }
+
+  // Check if we have children to show
+  const indent = span.parentId ? '   ' : '';
+
+  if (span.status === 'completed') {
+    return `${colors.green}${symbols.check}${colors.reset} ${indent}${span.name.padEnd(25)} ${colors.cyan}${duration}${colors.reset}${warning}`;
+  }
+
+  return `${indent}${span.name.padEnd(25)} ${duration}`;
+}
+
+/**
+ * Format a span error
+ */
+export function formatPhaseError(span: TelemetrySpan): string {
+  return `${colors.red}${symbols.error} ${span.name}${colors.reset} - ${span.errorMessage || 'Unknown error'}`;
+}
+
+/**
+ * Format the build summary
+ */
+export function formatSummary(report: TelemetryReport): string {
+  const success = report.summary.success;
+  const statusText = success ? `${colors.green}Success${colors.reset}` : `${colors.red}Failed${colors.reset}`;
+
+  const memoryDelta = report.summary.totalMemoryDelta;
+  const heapSign = memoryDelta.heapUsed >= 0 ? '+' : '';
+  const rssSign = memoryDelta.rss >= 0 ? '+' : '';
+
+  let summary = `
+${colors.bright}${symbols.chart} Build Summary${colors.reset}
+   Status: ${statusText}
+   Total Duration: ${colors.cyan}${formatDuration(report.summary.totalDuration)}${colors.reset}
+   Memory Delta: ${colors.dim}${heapSign}${formatBytes(memoryDelta.heapUsed)} heap, ${rssSign}${formatBytes(memoryDelta.rss)} RSS${colors.reset}`;
+
+  if (report.summary.bundleSize) {
+    summary += `\n   Bundle Size: ${colors.cyan}${formatBytes(report.summary.bundleSize)}${colors.reset}`;
+  }
+
+  if (report.summary.modulesCount) {
+    summary += `\n   Modules: ${colors.cyan}${report.summary.modulesCount}${colors.reset}`;
+  }
+
+  if (report.summary.errorMessage) {
+    summary += `\n\n${colors.red}Error: ${report.summary.errorMessage}${colors.reset}`;
+  }
+
+  return summary;
+}
+
+/**
+ * Format a warning message
+ */
+export function formatWarning(message: string): string {
+  return `${colors.yellow}${symbols.warning} Warning:${colors.reset} ${message}`;
+}
+
+/**
+ * Format an info message
+ */
+export function formatInfo(message: string): string {
+  return `${colors.cyan}${symbols.info}${colors.reset} ${message}`;
+}
+
+/**
+ * Format a hierarchical view of spans
+ */
+export function formatSpansTree(spans: TelemetrySpan[], indent: number = 0): string {
+  const lines: string[] = [];
+
+  // Get root spans (no parent)
+  const rootSpans = spans.filter((s) => !s.parentId);
+
+  function renderSpan(span: TelemetrySpan, depth: number) {
+    const prefix = '  '.repeat(depth);
+    const duration = span.duration ? formatDuration(span.duration) : 'N/A';
+    const status =
+      span.status === 'completed'
+        ? `${colors.green}${symbols.check}${colors.reset}`
+        : span.status === 'error'
+          ? `${colors.red}${symbols.error}${colors.reset}`
+          : `${colors.yellow}${symbols.hourglass}${colors.reset}`;
+
+    lines.push(`${prefix}${status} ${span.name}: ${colors.cyan}${duration}${colors.reset}`);
+
+    // Find children
+    const children = spans.filter((s) => s.parentId === span.id);
+    children.forEach((child) => renderSpan(child, depth + 1));
+  }
+
+  rootSpans.forEach((span) => renderSpan(span, indent));
+
+  return lines.join('\n');
+}
+
+/**
+ * Get all console formatters as an object
+ */
+export function getConsoleFormatters(): ConsoleFormatters {
+  return {
+    header: formatHeader,
+    buildConfig: formatBuildConfig,
+    phaseStart: formatPhaseStart,
+    phaseComplete: formatPhaseComplete,
+    phaseError: formatPhaseError,
+    summary: formatSummary,
+    warning: formatWarning,
+    info: formatInfo,
+  };
+}

--- a/packages/bundler-telemetry/src/html-reporter.ts
+++ b/packages/bundler-telemetry/src/html-reporter.ts
@@ -1,0 +1,649 @@
+/**
+ * HTML Reporter - Generate visual HTML reports for telemetry data
+ */
+
+import type { TelemetryReport } from './types';
+
+/**
+ * Format bytes to human readable string
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+/**
+ * Format duration to human readable string
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms.toFixed(0)}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`;
+  const minutes = Math.floor(ms / 60000);
+  const seconds = ((ms % 60000) / 1000).toFixed(0);
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Get status badge HTML
+ */
+function getStatusBadge(success: boolean): string {
+  return success
+    ? '<span class="badge badge-success">✓ Success</span>'
+    : '<span class="badge badge-error">✗ Failed</span>';
+}
+
+/**
+ * Generate bar chart HTML for phase durations
+ */
+function generatePhaseChart(spans: TelemetryReport['spans']): string {
+  const validSpans = spans.filter((s) => s.duration && s.duration > 0);
+  if (validSpans.length === 0) return '<p>No phase data available</p>';
+
+  const maxDuration = Math.max(...validSpans.map((s) => s.duration || 0));
+  const colors = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16'];
+
+  const bars = validSpans
+    .map((span, index) => {
+      const width = ((span.duration || 0) / maxDuration) * 100;
+      const color = colors[index % colors.length];
+      return `
+        <div class="bar-container">
+          <div class="bar-label" title="${span.name}">${span.name}</div>
+          <div class="bar-wrapper">
+            <div class="bar" style="width: ${width}%; background-color: ${color}"></div>
+          </div>
+          <div class="bar-value">${formatDuration(span.duration || 0)}</div>
+        </div>
+      `;
+    })
+    .join('');
+
+  return `<div class="chart">${bars}</div>`;
+}
+
+/**
+ * Generate timeline HTML for spans
+ */
+function generateTimeline(spans: TelemetryReport['spans']): string {
+  if (spans.length === 0) return '<p>No timeline data available</p>';
+
+  const sortedSpans = [...spans].sort((a, b) => a.startTime - b.startTime);
+  const minTime = sortedSpans[0]?.startTime || 0;
+  const maxTime = Math.max(...sortedSpans.map((s) => s.endTime || s.startTime));
+  const totalDuration = maxTime - minTime;
+
+  const timelineItems = sortedSpans
+    .map((span) => {
+      const start = ((span.startTime - minTime) / totalDuration) * 100;
+      const width = ((span.duration || 0) / totalDuration) * 100;
+      const statusClass = span.status === 'completed' ? 'completed' : span.status === 'error' ? 'error' : 'running';
+
+      return `
+        <div class="timeline-item">
+          <div class="timeline-label">${span.name}</div>
+          <div class="timeline-bar-wrapper">
+            <div class="timeline-bar ${statusClass}" style="margin-left: ${start}%; width: ${Math.max(width, 0.5)}%"></div>
+          </div>
+          <div class="timeline-duration">${formatDuration(span.duration || 0)}</div>
+        </div>
+      `;
+    })
+    .join('');
+
+  return `<div class="timeline">${timelineItems}</div>`;
+}
+
+/**
+ * Generate memory usage chart
+ */
+function generateMemoryChart(report: TelemetryReport): string {
+  const heapUsed = report.summary.totalMemoryDelta.heapUsed;
+  const rss = report.summary.totalMemoryDelta.rss;
+
+  const maxMemory = Math.max(Math.abs(heapUsed), Math.abs(rss), 1);
+  const heapWidth = (Math.abs(heapUsed) / maxMemory) * 100;
+  const rssWidth = (Math.abs(rss) / maxMemory) * 100;
+
+  return `
+    <div class="memory-chart">
+      <div class="memory-item">
+        <div class="memory-label">Heap Used</div>
+        <div class="memory-bar-wrapper">
+          <div class="memory-bar heap" style="width: ${heapWidth}%"></div>
+        </div>
+        <div class="memory-value ${heapUsed < 0 ? 'negative' : ''}">${heapUsed < 0 ? '-' : '+'}${formatBytes(Math.abs(heapUsed))}</div>
+      </div>
+      <div class="memory-item">
+        <div class="memory-label">RSS</div>
+        <div class="memory-bar-wrapper">
+          <div class="memory-bar rss" style="width: ${rssWidth}%"></div>
+        </div>
+        <div class="memory-value ${rss < 0 ? 'negative' : ''}">${rss < 0 ? '-' : '+'}${formatBytes(Math.abs(rss))}</div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Generate spans table HTML
+ */
+function generateSpansTable(spans: TelemetryReport['spans']): string {
+  if (spans.length === 0) return '<p>No span data available</p>';
+
+  const rows = spans
+    .map((span) => {
+      const memoryBefore = span.memoryBefore ? formatBytes(span.memoryBefore.heapUsed) : '-';
+      const memoryAfter = span.memoryAfter ? formatBytes(span.memoryAfter.heapUsed) : '-';
+      const statusBadge =
+        span.status === 'completed'
+          ? '<span class="badge badge-success">Completed</span>'
+          : span.status === 'error'
+            ? '<span class="badge badge-error">Error</span>'
+            : '<span class="badge badge-running">Running</span>';
+
+      return `
+        <tr>
+          <td><code>${span.name}</code></td>
+          <td>${formatDuration(span.duration || 0)}</td>
+          <td>${memoryBefore}</td>
+          <td>${memoryAfter}</td>
+          <td>${statusBadge}</td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  return `
+    <table class="spans-table">
+      <thead>
+        <tr>
+          <th>Phase</th>
+          <th>Duration</th>
+          <th>Memory Before</th>
+          <th>Memory After</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `;
+}
+
+/**
+ * Generate complete HTML report
+ */
+export function generateHTMLReport(report: TelemetryReport): string {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Build Telemetry Report</title>
+  <style>
+    :root {
+      --bg-color: #0f172a;
+      --card-bg: #1e293b;
+      --text-color: #f1f5f9;
+      --text-muted: #94a3b8;
+      --border-color: #334155;
+      --accent-color: #3b82f6;
+      --success-color: #10b981;
+      --error-color: #ef4444;
+      --warning-color: #f59e0b;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg-color: #f8fafc;
+        --card-bg: #ffffff;
+        --text-color: #1e293b;
+        --text-muted: #64748b;
+        --border-color: #e2e8f0;
+      }
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      line-height: 1.6;
+      padding: 2rem;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .subtitle {
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .card h2 {
+      font-size: 1.25rem;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 1rem;
+    }
+
+    .stat-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      padding: 1rem;
+    }
+
+    .stat-label {
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .stat-value {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-top: 0.25rem;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    .badge-success {
+      background: rgba(16, 185, 129, 0.2);
+      color: var(--success-color);
+    }
+
+    .badge-error {
+      background: rgba(239, 68, 68, 0.2);
+      color: var(--error-color);
+    }
+
+    .badge-running {
+      background: rgba(245, 158, 11, 0.2);
+      color: var(--warning-color);
+    }
+
+    .chart {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .bar-container {
+      display: grid;
+      grid-template-columns: 1fr 2fr 100px;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .bar-label {
+      font-size: 0.85rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .bar-wrapper {
+      background: var(--border-color);
+      border-radius: 4px;
+      height: 24px;
+      overflow: hidden;
+    }
+
+    .bar {
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.3s ease;
+    }
+
+    .bar-value {
+      text-align: right;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .timeline-item {
+      display: grid;
+      grid-template-columns: 1fr 3fr 100px;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .timeline-label {
+      font-size: 0.85rem;
+    }
+
+    .timeline-bar-wrapper {
+      background: var(--border-color);
+      border-radius: 4px;
+      height: 12px;
+      position: relative;
+    }
+
+    .timeline-bar {
+      position: absolute;
+      height: 100%;
+      border-radius: 4px;
+      min-width: 2px;
+    }
+
+    .timeline-bar.completed {
+      background: var(--success-color);
+    }
+
+    .timeline-bar.error {
+      background: var(--error-color);
+    }
+
+    .timeline-bar.running {
+      background: var(--warning-color);
+    }
+
+    .timeline-duration {
+      text-align: right;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .memory-chart {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .memory-item {
+      display: grid;
+      grid-template-columns: 120px 1fr 100px;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .memory-label {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .memory-bar-wrapper {
+      background: var(--border-color);
+      border-radius: 4px;
+      height: 20px;
+      overflow: hidden;
+    }
+
+    .memory-bar {
+      height: 100%;
+      border-radius: 4px;
+    }
+
+    .memory-bar.heap {
+      background: var(--accent-color);
+    }
+
+    .memory-bar.rss {
+      background: var(--success-color);
+    }
+
+    .memory-value {
+      font-size: 0.85rem;
+      text-align: right;
+    }
+
+    .memory-value.negative {
+      color: var(--error-color);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    th {
+      background: var(--bg-color);
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+    }
+
+    td {
+      font-size: 0.9rem;
+    }
+
+    code {
+      background: var(--bg-color);
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      font-family: 'Fira Code', 'Monaco', monospace;
+      font-size: 0.85rem;
+    }
+
+    .config-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+
+    .config-item {
+      padding: 0.75rem;
+      background: var(--bg-color);
+      border-radius: 4px;
+    }
+
+    .config-key {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .config-value {
+      font-size: 0.95rem;
+      margin-top: 0.25rem;
+    }
+
+    .error-message {
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid var(--error-color);
+      border-radius: 8px;
+      padding: 1rem;
+      margin-top: 1rem;
+    }
+
+    .error-message h3 {
+      color: var(--error-color);
+      margin-bottom: 0.5rem;
+    }
+
+    footer {
+      text-align: center;
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border-color);
+      color: var(--text-muted);
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🚀 Build Telemetry Report</h1>
+      <p class="subtitle">Generated on ${new Date(report.timestamp).toLocaleString()}</p>
+    </header>
+
+    <section class="card">
+      <h2>📊 Overview</h2>
+      <div class="grid">
+        <div class="stat-card">
+          <div class="stat-label">Status</div>
+          <div class="stat-value">${getStatusBadge(report.summary.success)}</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Total Duration</div>
+          <div class="stat-value">${formatDuration(report.summary.totalDuration)}</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Phases</div>
+          <div class="stat-value">${report.spans.length}</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Memory Delta</div>
+          <div class="stat-value">${formatBytes(Math.abs(report.summary.totalMemoryDelta.heapUsed))}</div>
+        </div>
+      </div>
+      ${report.summary.errorMessage ? `<div class="error-message"><h3>Error</h3><pre>${report.summary.errorMessage}</pre></div>` : ''}
+    </section>
+
+    <section class="card">
+      <h2>⚙️ Build Configuration</h2>
+      <div class="config-grid">
+        <div class="config-item">
+          <div class="config-key">Bundler</div>
+          <div class="config-value">${report.bundler}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Preset</div>
+          <div class="config-value">${report.preset}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Mode</div>
+          <div class="config-value">${report.production ? 'Production' : 'Development'}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Node.js</div>
+          <div class="config-value">${report.nodeVersion}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Platform</div>
+          <div class="config-value">${report.platform} (${report.arch})</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Bundler Version</div>
+          <div class="config-value">${report.bundlerVersion}</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>💻 System Info</h2>
+      <div class="config-grid">
+        <div class="config-item">
+          <div class="config-key">CPUs</div>
+          <div class="config-value">${report.systemInfo.cpus || 'N/A'}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Total Memory</div>
+          <div class="config-value">${formatBytes(report.systemInfo.totalMemory)}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Free Memory</div>
+          <div class="config-value">${formatBytes(report.systemInfo.freeMemory)}</div>
+        </div>
+        <div class="config-item">
+          <div class="config-key">Architecture</div>
+          <div class="config-value">${report.systemInfo.arch}</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>📈 Phase Duration Chart</h2>
+      ${generatePhaseChart(report.spans)}
+    </section>
+
+    <section class="card">
+      <h2>⏱️ Timeline</h2>
+      ${generateTimeline(report.spans)}
+    </section>
+
+    <section class="card">
+      <h2>💾 Memory Usage</h2>
+      ${generateMemoryChart(report)}
+    </section>
+
+    <section class="card">
+      <h2>📋 Detailed Phases</h2>
+      ${generateSpansTable(report.spans)}
+    </section>
+
+    <footer>
+      <p>Generated by @aziontech/bundler-telemetry</p>
+    </footer>
+  </div>
+</body>
+</html>`;
+
+  return html;
+}
+
+/**
+ * Save the HTML report to a file
+ */
+export async function saveHTMLReport(report: TelemetryReport, outputPath: string): Promise<void> {
+  // Dynamic import for fs/path to support browser-like environments
+  const fs = await import('fs');
+  const path = await import('path');
+
+  const dir = path.dirname(outputPath);
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  const html = generateHTMLReport(report);
+  await fs.promises.writeFile(outputPath, html, 'utf-8');
+}

--- a/packages/bundler-telemetry/src/index.test.ts
+++ b/packages/bundler-telemetry/src/index.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Tests for @aziontech/bundler-telemetry
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  TelemetryCollector,
+  createSummaryReport,
+  extractPluginMetrics,
+  formatBuildConfig,
+  formatBytes,
+  formatDuration,
+  formatHeader,
+  formatPhaseComplete,
+  formatSummary,
+  reportToJSON,
+} from './index';
+
+// Mock fs module
+jest.mock('fs');
+jest.mock('fs/promises');
+
+describe('TelemetryCollector', () => {
+  let collector: TelemetryCollector;
+
+  const mockConfig = {
+    enabled: true,
+    outputFormat: 'json' as const,
+    outputPath: '.edge/telemetry-report.json',
+  };
+
+  const mockMetadata = {
+    bundlerVersion: '7.2.0',
+    preset: 'nextjs',
+    bundler: 'esbuild' as const,
+    production: true,
+    entry: ['./src/main.ts'],
+  };
+
+  beforeEach(() => {
+    // Suppress console.log for cleaner test output
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    collector = new TelemetryCollector(mockConfig, mockMetadata);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create a collector instance', () => {
+      expect(collector).toBeInstanceOf(TelemetryCollector);
+    });
+
+    it('should initialize with correct metadata', () => {
+      const systemInfo = collector.getSystemInfo();
+      expect(systemInfo).toHaveProperty('cpus');
+      expect(systemInfo).toHaveProperty('totalMemory');
+      expect(systemInfo).toHaveProperty('freeMemory');
+      expect(systemInfo).toHaveProperty('platform');
+      expect(systemInfo).toHaveProperty('arch');
+    });
+  });
+
+  describe('startSpan / endSpan', () => {
+    it('should start and end a span', () => {
+      const spanId = collector.startSpan('test-phase');
+      expect(spanId).toBeTruthy();
+
+      collector.endSpan(spanId);
+
+      const span = collector.getSpan(spanId);
+      expect(span).toBeDefined();
+      expect(span?.status).toBe('completed');
+      expect(span?.duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should record error status when span fails', () => {
+      const spanId = collector.startSpan('failing-phase');
+      collector.endSpan(spanId, 'Something went wrong');
+
+      const span = collector.getSpan(spanId);
+      expect(span?.status).toBe('error');
+      expect(span?.errorMessage).toBe('Something went wrong');
+    });
+
+    it('should support nested spans', () => {
+      const parentId = collector.startSpan('parent-phase');
+      const childId = collector.startSpan('child-phase', {}, parentId);
+
+      collector.endSpan(childId);
+      collector.endSpan(parentId);
+
+      const childSpan = collector.getSpan(childId);
+      expect(childSpan?.parentId).toBe(parentId);
+    });
+  });
+
+  describe('measureAsync', () => {
+    it('should measure async function execution', async () => {
+      const result = await collector.measureAsync('async-operation', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return 'success';
+      });
+
+      expect(result).toBe('success');
+
+      const spans = collector.getAllSpans();
+      const asyncSpan = spans.find((s) => s.name === 'async-operation');
+      expect(asyncSpan).toBeDefined();
+      expect(asyncSpan?.duration).toBeGreaterThanOrEqual(10);
+    });
+
+    it('should record error when async function throws', async () => {
+      await expect(
+        collector.measureAsync('failing-async', async () => {
+          throw new Error('Async error');
+        }),
+      ).rejects.toThrow('Async error');
+
+      const spans = collector.getAllSpans();
+      const failedSpan = spans.find((s) => s.name === 'failing-async');
+      expect(failedSpan?.status).toBe('error');
+      expect(failedSpan?.errorMessage).toBe('Async error');
+    });
+  });
+
+  describe('measureSync', () => {
+    it('should measure sync function execution', () => {
+      const result = collector.measureSync('sync-operation', () => {
+        let sum = 0;
+        for (let i = 0; i < 1000; i++) sum += i;
+        return sum;
+      });
+
+      expect(result).toBe(499500);
+
+      const spans = collector.getAllSpans();
+      const syncSpan = spans.find((s) => s.name === 'sync-operation');
+      expect(syncSpan).toBeDefined();
+      expect(syncSpan?.duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should record error when sync function throws', () => {
+      expect(() =>
+        collector.measureSync('failing-sync', () => {
+          throw new Error('Sync error');
+        }),
+      ).toThrow('Sync error');
+
+      const spans = collector.getAllSpans();
+      const failedSpan = spans.find((s) => s.name === 'failing-sync');
+      expect(failedSpan?.status).toBe('error');
+    });
+  });
+
+  describe('disabled telemetry', () => {
+    it('should not collect telemetry when disabled', () => {
+      const disabledCollector = new TelemetryCollector({ ...mockConfig, enabled: false }, mockMetadata);
+
+      const spanId = disabledCollector.startSpan('test-phase');
+      disabledCollector.endSpan(spanId);
+
+      // Should still work, just not collect
+      expect(spanId).toBe('');
+      expect(disabledCollector.getAllSpans()).toHaveLength(0);
+    });
+  });
+
+  describe('getMemoryDelta', () => {
+    it('should return memory delta', () => {
+      const delta = collector.getMemoryDelta();
+      expect(delta).toHaveProperty('heapUsed');
+      expect(delta).toHaveProperty('rss');
+    });
+  });
+
+  describe('getTotalDuration', () => {
+    it('should return total duration', () => {
+      const duration = collector.getTotalDuration();
+      expect(duration).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+describe('Console Formatters', () => {
+  describe('formatDuration', () => {
+    it('should format milliseconds correctly', () => {
+      expect(formatDuration(50)).toBe('50ms');
+      expect(formatDuration(500)).toBe('500ms');
+    });
+
+    it('should format seconds correctly', () => {
+      expect(formatDuration(1500)).toBe('1.5s');
+      expect(formatDuration(10000)).toBe('10.0s');
+    });
+
+    it('should format minutes correctly', () => {
+      expect(formatDuration(65000)).toBe('1m 5s');
+      expect(formatDuration(125000)).toBe('2m 5s');
+    });
+  });
+
+  describe('formatBytes', () => {
+    it('should format bytes correctly', () => {
+      expect(formatBytes(512)).toBe('512B');
+      expect(formatBytes(1024)).toBe('1.0KB');
+      expect(formatBytes(1048576)).toBe('1.0MB');
+    });
+
+    it('should handle negative values', () => {
+      expect(formatBytes(-512)).toBe('-512B');
+      expect(formatBytes(-1048576)).toBe('-1.0MB');
+    });
+  });
+
+  describe('formatHeader', () => {
+    it('should format header with version', () => {
+      const result = formatHeader('7.2.0');
+      expect(result).toContain('Azion Bundler');
+      expect(result).toContain('7.2.0');
+    });
+  });
+
+  describe('formatBuildConfig', () => {
+    it('should format build configuration', () => {
+      const result = formatBuildConfig({
+        bundlerVersion: '7.2.0',
+        preset: 'nextjs',
+        bundler: 'esbuild',
+        production: true,
+        entry: './src/main.ts',
+      });
+      expect(result).toContain('nextjs');
+      expect(result).toContain('esbuild');
+      expect(result).toContain('production');
+    });
+  });
+
+  describe('formatPhaseComplete', () => {
+    it('should format completed phase', () => {
+      const span = {
+        id: 'span-1',
+        name: 'test-phase',
+        startTime: 100,
+        endTime: 200,
+        duration: 100,
+        status: 'completed' as const,
+        attributes: {},
+      };
+      const result = formatPhaseComplete(span);
+      expect(result).toContain('test-phase');
+      expect(result).toContain('100ms');
+    });
+
+    it('should format error phase', () => {
+      const span = {
+        id: 'span-1',
+        name: 'error-phase',
+        startTime: 100,
+        endTime: 200,
+        duration: 100,
+        status: 'error' as const,
+        errorMessage: 'Build failed',
+        attributes: {},
+      };
+      const result = formatPhaseComplete(span);
+      expect(result).toContain('FAILED');
+      expect(result).toContain('Build failed');
+    });
+  });
+
+  describe('formatSummary', () => {
+    it('should format successful build summary', () => {
+      const report = {
+        bundlerVersion: '7.2.0',
+        nodeVersion: 'v18.20.0',
+        platform: 'darwin',
+        arch: 'x64',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        preset: 'nextjs',
+        bundler: 'esbuild' as const,
+        production: true,
+        entry: './src/main.ts',
+        systemInfo: {
+          cpus: 8,
+          totalMemory: 16384,
+          freeMemory: 8192,
+          platform: 'darwin',
+          arch: 'x64',
+        },
+        spans: [],
+        summary: {
+          totalDuration: 2400,
+          totalMemoryDelta: {
+            heapUsed: 150000000,
+            rss: 200000000,
+          },
+          success: true,
+        },
+      };
+      const result = formatSummary(report);
+      expect(result).toContain('Success');
+      expect(result).toContain('2.4s');
+    });
+  });
+});
+
+describe('Reporter Utilities', () => {
+  describe('reportToJSON', () => {
+    it('should convert report to JSON string', () => {
+      const report = {
+        bundlerVersion: '7.2.0',
+        nodeVersion: 'v18.20.0',
+        platform: 'darwin',
+        arch: 'x64',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        preset: 'nextjs',
+        bundler: 'esbuild' as const,
+        production: true,
+        entry: './src/main.ts',
+        systemInfo: {
+          cpus: 8,
+          totalMemory: 16384,
+          freeMemory: 8192,
+          platform: 'darwin',
+          arch: 'x64',
+        },
+        spans: [],
+        summary: {
+          totalDuration: 2400,
+          totalMemoryDelta: {
+            heapUsed: 150000000,
+            rss: 200000000,
+          },
+          success: true,
+        },
+      };
+
+      const json = reportToJSON(report);
+      expect(() => JSON.parse(json)).not.toThrow();
+      expect(json).toContain('bundlerVersion');
+    });
+
+    it('should support pretty print option', () => {
+      const report = {
+        bundlerVersion: '7.2.0',
+        nodeVersion: 'v18.20.0',
+        platform: 'darwin',
+        arch: 'x64',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        preset: 'nextjs',
+        bundler: 'esbuild' as const,
+        production: true,
+        entry: './src/main.ts',
+        systemInfo: {
+          cpus: 8,
+          totalMemory: 16384,
+          freeMemory: 8192,
+          platform: 'darwin',
+          arch: 'x64',
+        },
+        spans: [],
+        summary: {
+          totalDuration: 2400,
+          totalMemoryDelta: {
+            heapUsed: 150000000,
+            rss: 200000000,
+          },
+          success: true,
+        },
+      };
+
+      const prettyJson = reportToJSON(report, { prettyPrint: true });
+      const compactJson = reportToJSON(report, { prettyPrint: false });
+
+      expect(prettyJson.length).toBeGreaterThan(compactJson.length);
+    });
+  });
+
+  describe('createSummaryReport', () => {
+    it('should create a summary report', () => {
+      const report = {
+        bundlerVersion: '7.2.0',
+        nodeVersion: 'v18.20.0',
+        platform: 'darwin',
+        arch: 'x64',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        preset: 'nextjs',
+        bundler: 'esbuild' as const,
+        production: true,
+        entry: './src/main.ts',
+        systemInfo: {
+          cpus: 8,
+          totalMemory: 16384,
+          freeMemory: 8192,
+          platform: 'darwin',
+          arch: 'x64',
+        },
+        spans: [{ id: '1', name: 'phase-1', status: 'completed' as const, startTime: 0, attributes: {} }],
+        summary: {
+          totalDuration: 2400,
+          totalMemoryDelta: {
+            heapUsed: 150000000,
+            rss: 200000000,
+          },
+          success: true,
+        },
+      };
+
+      const summary = createSummaryReport(report);
+      expect(summary).toHaveProperty('bundlerVersion', '7.2.0');
+      expect(summary).toHaveProperty('preset', 'nextjs');
+      expect(summary).toHaveProperty('phaseCount', 1);
+    });
+  });
+
+  describe('extractPluginMetrics', () => {
+    it('should extract plugin metrics from spans', () => {
+      const spans = [
+        {
+          id: '1',
+          name: 'plugin:esbuild-plugin',
+          duration: 100,
+          status: 'completed' as const,
+          startTime: 0,
+          attributes: {},
+        },
+        {
+          id: '2',
+          name: 'plugin:webpack-plugin',
+          duration: 200,
+          status: 'completed' as const,
+          startTime: 0,
+          attributes: { filesProcessed: 10 },
+        },
+        { id: '3', name: 'regular-phase', duration: 50, status: 'completed' as const, startTime: 0, attributes: {} },
+      ];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const plugins = extractPluginMetrics(spans as any);
+      expect(plugins).toHaveLength(2);
+      expect(plugins[0].name).toBe('esbuild-plugin');
+      expect(plugins[1].filesProcessed).toBe(10);
+    });
+  });
+});

--- a/packages/bundler-telemetry/src/index.ts
+++ b/packages/bundler-telemetry/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * @aziontech/bundler-telemetry
+ *
+ * Telemetry system for measuring and reporting build performance in Azion Bundler
+ */
+
+// Main class
+export { TelemetryCollector } from './collector';
+
+// Types
+export type {
+  ConsoleFormatters,
+  ReportOptions,
+  SpanTreeNode,
+  TelemetryBuildMetadata,
+  TelemetryConfig,
+  TelemetryOutputFormat,
+  TelemetryPhaseMetrics,
+  TelemetryPluginMetrics,
+  TelemetryReport,
+  TelemetrySpan,
+  TelemetrySystemInfo,
+} from './types';
+
+// Console formatters
+export {
+  formatBuildConfig,
+  formatBytes,
+  formatDuration,
+  formatHeader,
+  formatInfo,
+  formatPhaseComplete,
+  formatPhaseError,
+  formatPhaseStart,
+  formatSpansTree,
+  formatSummary,
+  formatWarning,
+  getConsoleFormatters,
+} from './console';
+
+// Report utilities
+export {
+  compareReports,
+  createSummaryReport,
+  extractPluginMetrics,
+  generateReport,
+  loadReport,
+  reportToJSON,
+  runPhaseWithTelemetry,
+  saveReport,
+} from './reporter';
+
+// HTML Reporter
+export { generateHTMLReport, saveHTMLReport } from './html-reporter';

--- a/packages/bundler-telemetry/src/reporter.ts
+++ b/packages/bundler-telemetry/src/reporter.ts
@@ -1,0 +1,253 @@
+/**
+ * Reporter module for generating and saving telemetry reports
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { TelemetryCollector } from './collector';
+import { formatPhaseComplete, formatPhaseStart } from './console';
+import type {
+  ReportOptions,
+  TelemetryBuildMetadata,
+  TelemetryOutputFormat,
+  TelemetryPluginMetrics,
+  TelemetryReport,
+} from './types';
+
+/**
+ * Get the current package version from package.json
+ */
+function getPackageVersion(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require('../package.json');
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/**
+ * Generate a telemetry report from the collector data
+ */
+export function generateReport(collector: TelemetryCollector, metadata: TelemetryBuildMetadata): TelemetryReport {
+  const spans = collector.getAllSpans();
+  const memoryDelta = collector.getMemoryDelta();
+
+  const report: TelemetryReport = {
+    bundlerVersion: metadata.bundlerVersion || getPackageVersion(),
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    timestamp: new Date().toISOString(),
+    preset: metadata.preset,
+    bundler: metadata.bundler,
+    production: metadata.production,
+    entry: metadata.entry,
+    systemInfo: collector.getSystemInfo(),
+    spans: spans,
+    summary: {
+      totalDuration: collector.getTotalDuration(),
+      totalMemoryDelta: memoryDelta,
+      success: collector.getBuildSuccess(),
+      errorMessage: collector.getErrorMessage(),
+    },
+  };
+
+  return report;
+}
+
+/**
+ * Extract plugin metrics from spans
+ */
+export function extractPluginMetrics(spans: TelemetryReport['spans']): TelemetryPluginMetrics[] {
+  const pluginSpans = spans.filter((span) => span.name.startsWith('plugin:') || span.name.includes('-plugin'));
+
+  return pluginSpans.map((span) => ({
+    name: span.name.replace(/^plugin:/, ''),
+    duration: span.duration || 0,
+    filesProcessed: span.attributes?.filesProcessed as number | undefined,
+  }));
+}
+
+/**
+ * Convert report to JSON string
+ */
+export function reportToJSON(report: TelemetryReport, options?: ReportOptions): string {
+  const includeAllSpans = options?.includeAllSpans ?? true;
+  const prettyPrint = options?.prettyPrint ?? true;
+
+  let spans = report.spans;
+  if (!includeAllSpans) {
+    // Only include top-level spans (no parent)
+    spans = spans.filter((span) => !span.parentId);
+  }
+
+  // Convert memory usage values to serializable format
+  const serializedReport = serializeReport({ ...report, spans });
+
+  return prettyPrint ? JSON.stringify(serializedReport, null, 2) : JSON.stringify(serializedReport);
+}
+
+/**
+ * Serialized telemetry report for JSON output
+ */
+interface SerializedTelemetryReport extends Omit<TelemetryReport, 'spans'> {
+  spans: Array<
+    Omit<TelemetryReport['spans'][number], 'memoryBefore' | 'memoryAfter'> & {
+      memoryBefore?: Record<string, number>;
+      memoryAfter?: Record<string, number>;
+    }
+  >;
+}
+
+/**
+ * Serialize memory usage values in the report for JSON output
+ */
+function serializeReport(report: TelemetryReport): SerializedTelemetryReport {
+  const serialized = JSON.parse(JSON.stringify(report)) as TelemetryReport;
+
+  // Serialize memory usage in spans
+  const spans = serialized.spans.map((span) => ({
+    ...span,
+    memoryBefore: span.memoryBefore ? serializeMemoryUsage(span.memoryBefore) : undefined,
+    memoryAfter: span.memoryAfter ? serializeMemoryUsage(span.memoryAfter) : undefined,
+  }));
+
+  return { ...serialized, spans } as SerializedTelemetryReport;
+}
+
+/**
+ * Serialize NodeJS.MemoryUsage to a plain object
+ */
+function serializeMemoryUsage(memory: NodeJS.MemoryUsage): Record<string, number> {
+  return {
+    rss: memory.rss,
+    heapTotal: memory.heapTotal,
+    heapUsed: memory.heapUsed,
+    external: memory.external,
+    arrayBuffers: memory.arrayBuffers,
+  };
+}
+
+/**
+ * Save the telemetry report to a JSON file
+ */
+export async function saveReport(report: TelemetryReport, outputPath: string): Promise<void> {
+  const dir = path.dirname(outputPath);
+
+  // Ensure the directory exists
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  // Write the report
+  const jsonContent = reportToJSON(report);
+  await fs.promises.writeFile(outputPath, jsonContent, 'utf-8');
+}
+
+/**
+ * Load a telemetry report from a JSON file
+ */
+export async function loadReport(inputPath: string): Promise<TelemetryReport> {
+  const content = await fs.promises.readFile(inputPath, 'utf-8');
+  return JSON.parse(content) as TelemetryReport;
+}
+
+/**
+ * Create a summary report (subset of full report for quick viewing)
+ */
+export function createSummaryReport(report: TelemetryReport): {
+  bundlerVersion: string;
+  preset: string;
+  bundler: string;
+  production: boolean;
+  totalDuration: number;
+  success: boolean;
+  phaseCount: number;
+  errorMessage?: string;
+} {
+  return {
+    bundlerVersion: report.bundlerVersion,
+    preset: report.preset,
+    bundler: report.bundler,
+    production: report.production,
+    totalDuration: report.summary.totalDuration,
+    success: report.summary.success,
+    phaseCount: report.spans.length,
+    errorMessage: report.summary.errorMessage,
+  };
+}
+
+/**
+ * Compare two telemetry reports and return the differences
+ */
+export function compareReports(
+  report1: TelemetryReport,
+  report2: TelemetryReport,
+): {
+  durationDelta: number;
+  memoryDelta: { heapUsed: number; rss: number };
+  phaseDiffs: Array<{ name: string; durationDelta: number }>;
+} {
+  // Duration difference
+  const durationDelta = report2.summary.totalDuration - report1.summary.totalDuration;
+
+  // Memory difference
+  const memoryDelta = {
+    heapUsed: report2.summary.totalMemoryDelta.heapUsed - report1.summary.totalMemoryDelta.heapUsed,
+    rss: report2.summary.totalMemoryDelta.rss - report1.summary.totalMemoryDelta.rss,
+  };
+
+  // Phase by phase comparison
+  const phaseDiffs: Array<{ name: string; durationDelta: number }> = [];
+
+  for (const span2 of report2.spans) {
+    const span1 = report1.spans.find((s) => s.name === span2.name);
+    if (span1 && span1.duration && span2.duration) {
+      phaseDiffs.push({
+        name: span2.name,
+        durationDelta: span2.duration - span1.duration,
+      });
+    }
+  }
+
+  return {
+    durationDelta,
+    memoryDelta,
+    phaseDiffs,
+  };
+}
+
+export const runPhaseWithTelemetry = async <T>(
+  telemetry: TelemetryCollector,
+  telemetryEnabled: boolean,
+  outputFormat: TelemetryOutputFormat,
+  phaseName: string,
+  displayName: string,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const spanId = telemetry.startSpan(phaseName);
+  if (telemetryEnabled && outputFormat !== 'json' && outputFormat !== 'html') {
+    console.log(
+      formatPhaseStart({
+        id: spanId,
+        name: displayName,
+        attributes: {},
+        status: 'running',
+        startTime: Date.now(),
+      }),
+    );
+  }
+  try {
+    const result = await fn();
+    telemetry.endSpan(spanId);
+    if (telemetryEnabled && outputFormat !== 'json' && outputFormat !== 'html') {
+      const span = telemetry.getSpan(spanId);
+      if (span) console.log(formatPhaseComplete(span));
+    }
+    return result;
+  } catch (error) {
+    telemetry.endSpan(spanId);
+    throw error;
+  }
+};

--- a/packages/bundler-telemetry/src/types.ts
+++ b/packages/bundler-telemetry/src/types.ts
@@ -1,0 +1,171 @@
+/**
+ * Telemetry types for @aziontech/bundler-telemetry
+ */
+
+/**
+ * Configuration for the telemetry collector
+ */
+export interface TelemetryConfig {
+  /** Enable or disable telemetry collection */
+  enabled: boolean;
+  /** Output format for telemetry data */
+  outputFormat: TelemetryOutputFormat;
+  /** Path to save the JSON report */
+  outputPath: string;
+  /** Path to save the HTML report (optional, defaults to same directory as JSON with .html extension) */
+  htmlOutputPath?: string;
+  /** OpenTelemetry integration options (optional) */
+  openTelemetry?: {
+    enabled: boolean;
+    endpoint?: string;
+    serviceName: string;
+  };
+}
+
+export type TelemetryOutputFormat = 'console' | 'json' | 'both' | 'html';
+
+/**
+ * Represents a single span of telemetry data
+ */
+export interface TelemetrySpan {
+  /** Unique identifier for the span */
+  id: string;
+  /** Name of the span */
+  name: string;
+  /** Parent span ID (for nested spans) */
+  parentId?: string;
+  /** Start time in milliseconds (from performance.now()) */
+  startTime: number;
+  /** End time in milliseconds (from performance.now()) */
+  endTime?: number;
+  /** Duration in milliseconds */
+  duration?: number;
+  /** Additional attributes/metadata for the span */
+  attributes: Record<string, unknown>;
+  /** Memory usage before the span started */
+  memoryBefore?: NodeJS.MemoryUsage;
+  /** Memory usage after the span ended */
+  memoryAfter?: NodeJS.MemoryUsage;
+  /** Status of the span */
+  status: 'running' | 'completed' | 'error';
+  /** Error message if status is 'error' */
+  errorMessage?: string;
+}
+
+/**
+ * Metrics for a build phase
+ */
+export interface TelemetryPhaseMetrics {
+  name: string;
+  startTime: number;
+  endTime: number;
+  duration: number;
+  memoryBefore: NodeJS.MemoryUsage;
+  memoryAfter: NodeJS.MemoryUsage;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Metrics for a plugin execution
+ */
+export interface TelemetryPluginMetrics {
+  name: string;
+  duration: number;
+  filesProcessed?: number;
+}
+
+/**
+ * System information collected at build start
+ */
+export interface TelemetrySystemInfo {
+  cpus: number;
+  totalMemory: number;
+  freeMemory: number;
+  platform: string;
+  arch: string;
+}
+
+/**
+ * Complete telemetry report for a build
+ */
+export interface TelemetryReport {
+  /** Version of the bundler */
+  bundlerVersion: string;
+  /** Node.js version */
+  nodeVersion: string;
+  /** Platform (darwin, linux, win32, etc.) */
+  platform: string;
+  /** Architecture (x64, arm64, etc.) */
+  arch: string;
+  /** ISO timestamp of the build */
+  timestamp: string;
+  /** Preset used (nextjs, react, etc.) */
+  preset: string;
+  /** Bundler used (esbuild or webpack) */
+  bundler: 'esbuild' | 'webpack';
+  /** Whether this was a production build */
+  production: boolean;
+  /** Entry point(s) for the build */
+  entry: string | string[];
+  /** System information */
+  systemInfo: TelemetrySystemInfo;
+  /** All spans recorded during the build */
+  spans: TelemetrySpan[];
+  /** Plugin metrics (if any) */
+  plugins?: TelemetryPluginMetrics[];
+  /** Build summary */
+  summary: {
+    totalDuration: number;
+    totalMemoryDelta: {
+      heapUsed: number;
+      rss: number;
+    };
+    bundleSize?: number;
+    modulesCount?: number;
+    success: boolean;
+    errorMessage?: string;
+  };
+}
+
+/**
+ * Build metadata passed to the telemetry collector
+ */
+export interface TelemetryBuildMetadata {
+  bundlerVersion: string;
+  preset: string;
+  bundler: 'esbuild' | 'webpack';
+  production: boolean;
+  entry: string | string[];
+}
+
+/**
+ * Console formatter functions
+ */
+export interface ConsoleFormatters {
+  phaseStart: (span: TelemetrySpan) => string;
+  phaseComplete: (span: TelemetrySpan) => string;
+  phaseError: (span: TelemetrySpan) => string;
+  summary: (report: TelemetryReport) => string;
+  warning: (message: string) => string;
+  info: (message: string) => string;
+  header: (bundlerVersion: string) => string;
+  buildConfig: (metadata: TelemetryBuildMetadata) => string;
+}
+
+/**
+ * Options for generating a report
+ */
+export interface ReportOptions {
+  /** Include all spans or just top-level ones */
+  includeAllSpans?: boolean;
+  /** Pretty print JSON output */
+  prettyPrint?: boolean;
+}
+
+/**
+ * Span tree node for hierarchical display
+ */
+export interface SpanTreeNode {
+  span: TelemetrySpan;
+  children: SpanTreeNode[];
+}

--- a/packages/bundler-telemetry/tsconfig.json
+++ b/packages/bundler-telemetry/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "ESNext",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  }
+}

--- a/packages/bundler-telemetry/vite.config.mjs
+++ b/packages/bundler-telemetry/vite.config.mjs
@@ -1,0 +1,7 @@
+import { createViteConfig } from '@aziontech/vite-config';
+
+export default createViteConfig({
+  dirname: __dirname,
+  ssr: true,
+  external: ['os', 'fs', 'path'],
+});

--- a/packages/presets/src/presets/svelte/kit/files/worker.js
+++ b/packages/presets/src/presets/svelte/kit/files/worker.js
@@ -1,4 +1,4 @@
-import { lookup as lookupCache, save as saveCache } from '@aziontech/preset/sveltekit/cache';
+import { lookup as lookupCache, save as saveCache } from '@aziontech/presets/preset/sveltekit/cache/default';
 import { base_path, manifest, prerendered } from 'MANIFEST';
 import { Server } from 'SERVER';
 

--- a/packages/presets/src/presets/svelte/prebuild.ts
+++ b/packages/presets/src/presets/svelte/prebuild.ts
@@ -8,7 +8,7 @@ const AZION_CONFIG_FILES = ['azion.config.js', 'azion.config.ts', 'azion.config.
 const PATHS = {
   BUILD_DIR_DEFAULT: 'build',
   AZION_BUILD_DIR: '.svelte-kit/azion',
-  WORKER_FILE: '.svelte-kit/@aziontech/_worker.js',
+  WORKER_FILE: '.svelte-kit/azion/_worker.js',
 } as const;
 
 async function readSvelteConfig() {
@@ -26,8 +26,8 @@ async function readSvelteConfig() {
     }
 
     const content = await readFile(configPath, 'utf8');
-    const hasAzionPreset = /azion\/preset\/sveltekit/i.test(content);
-    const hasAzionAdapter = /@sveltejs\/adapter-@aziontech/i.test(content);
+    const hasAzionPreset = /@aziontech\/presets\/preset\/sveltekit/i.test(content);
+    const hasAzionAdapter = /@sveltejs\/adapter-azion/i.test(content);
     const hasAzionConfig = hasAzionPreset || hasAzionAdapter;
 
     // check if adapater-static and assets,pages config exists

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,30 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
 
+  packages/bundler-telemetry:
+    devDependencies:
+      '@aziontech/vite-config':
+        specifier: workspace:*
+        version: link:../vite-config
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.13.1
+        version: 22.19.15
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.1.5
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
+
   packages/client:
     dependencies:
       '@aziontech/ai':
@@ -4625,7 +4649,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.15.0:


### PR DESCRIPTION
This pull request introduces a new package, `@aziontech/bundler-telemetry`, which provides a telemetry system for measuring and reporting build performance in the Azion Bundler. The package includes a main collector class, console output utilities, report generation, and type definitions, along with documentation and test configuration. The most important changes are summarized below:

**New Package Introduction:**

* Added the `@aziontech/bundler-telemetry` package with a `TelemetryCollector` class for tracking build performance, including span management, report generation, and console/JSON/HTML output support. [[1]](diffhunk://#diff-2a43fde54a46350ed9c560383836b4f94a4b3ecb3359f9004bd2de8e53856febR1-R312) [[2]](diffhunk://#diff-e6a6faab4223894bfbf3cc1ee9628f7dee6689d4f91fa96cc258003b92f77967R1-R39) [[3]](diffhunk://#diff-2828f58d0718a2867f548d7c5ddfd1e3e7a69082c37784379ad83c0fd07ffce8R1-R54)

**Documentation:**

* Added a comprehensive `README.md` documenting installation, usage examples, API reference, output formats, and environment variables for the new telemetry package.

**Console and Reporting Utilities:**

* Implemented console output formatters for real-time and summary telemetry display, including colorized output and hierarchical span visualization.
* Provided report generation and utility functions, as well as HTML report support.

**Testing and Configuration:**

* Added a Jest configuration file for running tests on the telemetry package.

**Release Management:**

* Added a changeset to document the introduction of the new major package.