### PR TITLE
chore: package improvements

### DIFF
--- a/packages/applications/tsconfig.json
+++ b/packages/applications/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2022",
     "module": "ESNext",
     "outDir": "./dist",
+    "rootDir": "./src",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/packages/builder/vite.config.mjs
+++ b/packages/builder/vite.config.mjs
@@ -1,17 +1,15 @@
 import { createViteConfig } from '@aziontech/vite-config';
-import { resolve } from 'path';
 
 export default createViteConfig({
   dirname: __dirname,
   ssr: true,
-  alias: {
-    '@aziontech/unenv-preset': resolve(__dirname, '../unenv-preset/src/'),
-    '@aziontech/utils/node': resolve(__dirname, '../utils/src/node/'),
-  },
   external: [
     '@edge-runtime/primitives',
     '@fastly/http-compute-js',
     '@aziontech/unenv-preset',
+    '@aziontech/utils',
+    '@aziontech/config',
+    '@aziontech/presets',
     'accepts',
     'browserify-zlib',
     'dotenv',

--- a/packages/bundler-telemetry/README.md
+++ b/packages/bundler-telemetry/README.md
@@ -238,10 +238,6 @@ compareReports(report1: TelemetryReport, report2: TelemetryReport): object
 extractPluginMetrics(spans: TelemetrySpan[]): TelemetryPluginMetrics[]
 ```
 
-## Environment Variables
-
-- `AZION_TELEMETRY=false` - Disable telemetry collection
-
 ## License
 
 MIT

--- a/packages/bundler-telemetry/src/collector.ts
+++ b/packages/bundler-telemetry/src/collector.ts
@@ -309,4 +309,8 @@ export class TelemetryCollector {
   private generateSpanId(): string {
     return `span_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
   }
+
+  getConfig(): TelemetryConfig {
+    return this.config;
+  }
 }

--- a/packages/bundler-telemetry/src/reporter.ts
+++ b/packages/bundler-telemetry/src/reporter.ts
@@ -219,14 +219,14 @@ export function compareReports(
 }
 
 export const runPhaseWithTelemetry = async <T>(
-  telemetry: TelemetryCollector,
-  telemetryEnabled: boolean,
-  outputFormat: TelemetryOutputFormat,
+  telemetry: TelemetryCollector | undefined,
+  telemetryEnabled: boolean | undefined,
+  outputFormat: TelemetryOutputFormat | undefined,
   phaseName: string,
   displayName: string,
   fn: () => Promise<T>,
 ): Promise<T> => {
-  const spanId = telemetry.startSpan(phaseName);
+  const spanId = telemetry?.startSpan(phaseName) ?? '';
   if (telemetryEnabled && outputFormat !== 'json' && outputFormat !== 'html') {
     console.log(
       formatPhaseStart({
@@ -240,14 +240,14 @@ export const runPhaseWithTelemetry = async <T>(
   }
   try {
     const result = await fn();
-    telemetry.endSpan(spanId);
+    telemetry?.endSpan(spanId);
     if (telemetryEnabled && outputFormat !== 'json' && outputFormat !== 'html') {
-      const span = telemetry.getSpan(spanId);
+      const span = telemetry?.getSpan(spanId);
       if (span) console.log(formatPhaseComplete(span));
     }
     return result;
   } catch (error) {
-    telemetry.endSpan(spanId);
+    telemetry?.endSpan(spanId);
     throw error;
   }
 };

--- a/packages/client/vite.config.mjs
+++ b/packages/client/vite.config.mjs
@@ -1,20 +1,8 @@
 import { createViteConfig } from '@aziontech/vite-config';
-import { resolve } from 'path';
 
 export default createViteConfig({
   dirname: __dirname,
   ssr: true,
-  alias: {
-    '@aziontech/ai': resolve(__dirname, '../ai/src/'),
-    '@aziontech/sql': resolve(__dirname, '../sql/src/'),
-    '@aziontech/storage': resolve(__dirname, '../storage/src/'),
-    '@aziontech/purge': resolve(__dirname, '../purge/src/'),
-    '@aziontech/config': resolve(__dirname, '../config/src/'),
-    '@aziontech/domains': resolve(__dirname, '../domains/src/'),
-    '@aziontech/applications': resolve(__dirname, '../applications/src/'),
-    '@aziontech/types': resolve(__dirname, '../types/src/'),
-    azion: resolve(__dirname, './src/'),
-  },
   dts: {
     aliasesExclude: [/^azion\//],
   },

--- a/packages/config/vite.config.mjs
+++ b/packages/config/vite.config.mjs
@@ -1,5 +1,4 @@
 import { createViteConfig } from '@aziontech/vite-config';
-import { resolve } from 'path';
 
 export default createViteConfig({
   dirname: __dirname,
@@ -7,11 +6,6 @@ export default createViteConfig({
   entry: {
     index: 'src/index.ts',
     rules: 'src/rules/index.ts',
-  },
-  alias: {
-    '@aziontech/unenv-preset': resolve(__dirname, '../unenv-preset/src/'),
-    '@aziontech/utils/node': resolve(__dirname, '../utils/src/node/'),
-    '@aziontech/builder': resolve(__dirname, '../builder/src/'),
   },
   external: ['ajv', 'ajv-errors', 'ajv-keywords', 'mathjs'],
   dts: {

--- a/packages/presets/docs/preset-nuxt.md
+++ b/packages/presets/docs/preset-nuxt.md
@@ -26,7 +26,7 @@ const require = createRequire(import.meta.url);
 
 export default defineNuxtConfig({
   nitro: {
-    preset: require.resolve('@aziontech/preset/nuxt/ssr'),
+    preset: require.resolve('@aziontech/presets/nuxt/ssr'),
   },
 });
 ```
@@ -36,7 +36,7 @@ Or directly with the path node_modules:
 ```typescript
 export default defineNuxtConfig({
   nitro: {
-    preset: './node_modules/@aziontech/packages/presets/src/presets/nuxt/nitro/ssr',
+    preset: './node_modules/@aziontech/presets/src/presets/nuxt/nitro/ssr',
   },
 });
 ```
@@ -49,7 +49,7 @@ If you're using `nuxt-og-image` in your project with SSR, you need to add the fo
 export default defineNuxtConfig({
   modules: ['nuxt-og-image'],
   nitro: {
-    preset: require.resolve('@aziontech/preset/nuxt/ssr'),
+    preset: require.resolve('@aziontech/presets/nuxt/ssr'),
   },
   ogImage: {
     compatibility: {
@@ -73,7 +73,7 @@ const require = createRequire(import.meta.url);
 
 export default defineNuxtConfig({
   nitro: {
-    preset: require.resolve('@aziontech/preset/nuxt/ssg'),
+    preset: require.resolve('@aziontech/presets/nuxt/ssg'),
   },
 });
 ```
@@ -83,7 +83,7 @@ Or directly with the path node_modules:
 ```typescript
 export default defineNuxtConfig({
   nitro: {
-    preset: './node_modules/@aziontech/packages/presets/src/presets/nuxt/nitro/ssg',
+    preset: './node_modules/@aziontech/presets/src/presets/nuxt/nitro/ssg',
   },
 });
 ```

--- a/packages/presets/docs/preset-svelte.md
+++ b/packages/presets/docs/preset-svelte.md
@@ -21,7 +21,7 @@ npm install azion
 Configure your `svelte.config.js` to use the Azion SSR adapter:
 
 ```javascript
-import adapter from '@aziontech/preset/svelte/ssr';
+import adapter from '@aziontech/preset/sveltekit';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -36,7 +36,6 @@
   ],
   "dependencies": {
     "@aziontech/config": "workspace:*",
-    "@aziontech/presets": "workspace:*",
     "@aziontech/types": "workspace:*",
     "@aziontech/unenv-preset": "workspace:*",
     "@aziontech/utils": "workspace:*",
@@ -45,6 +44,7 @@
     "pcre-to-regexp": "^1.1.0",
     "semver": "^7.7.4",
     "ts-jest": "^29.4.9",
+    "mime-types": "^3.0.1",
     "webpack": "^5.97.1"
   },
   "devDependencies": {

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -19,10 +19,10 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
-    "./preset/nuxt/*": "./src/presets/nuxt/nitro/*/index.js",
-    "./preset/sveltekit/*": "./src/presets/svelte/kit/index.js",
-    "./preset/sveltekit/cache/*": "./src/presets/svelte/kit/cache/index.js",
-    "./presets/preset/*": "./dist/presets/*"
+    "./nuxt/*": "./src/presets/nuxt/nitro/*/index.js",
+    "./sveltekit": "./src/presets/svelte/kit/index.js",
+    "./sveltekit/cache": "./src/presets/svelte/kit/cache/index.js",
+    "./preset/*": "./dist/presets/*"
   },
   "author": "aziontech",
   "license": "MIT",

--- a/packages/presets/src/presets/svelte/kit/files/worker.js
+++ b/packages/presets/src/presets/svelte/kit/files/worker.js
@@ -1,4 +1,4 @@
-import { lookup as lookupCache, save as saveCache } from '@aziontech/presets/preset/sveltekit/cache/default';
+import { lookup as lookupCache, save as saveCache } from '@aziontech/presets/sveltekit/cache';
 import { base_path, manifest, prerendered } from 'MANIFEST';
 import { Server } from 'SERVER';
 

--- a/packages/presets/src/presets/svelte/prebuild.ts
+++ b/packages/presets/src/presets/svelte/prebuild.ts
@@ -26,7 +26,7 @@ async function readSvelteConfig() {
     }
 
     const content = await readFile(configPath, 'utf8');
-    const hasAzionPreset = /@aziontech\/presets\/preset\/sveltekit/i.test(content);
+    const hasAzionPreset = /@aziontech\/presets\/sveltekit/i.test(content);
     const hasAzionAdapter = /@sveltejs\/adapter-azion/i.test(content);
     const hasAzionConfig = hasAzionPreset || hasAzionAdapter;
 

--- a/packages/presets/vite.config.mjs
+++ b/packages/presets/vite.config.mjs
@@ -1,20 +1,8 @@
 import { createViteConfig } from '@aziontech/vite-config';
-import { resolve } from 'path';
 
 export default createViteConfig({
   dirname: __dirname,
   ssr: true,
-  alias: {
-    '@aziontech/unenv-preset': resolve(__dirname, '../unenv-preset/src/'),
-    '@aziontech/utils/edge': resolve(__dirname, '../utils/src/edge/'),
-    '@aziontech/utils/node': resolve(__dirname, '../utils/src/node/'),
-    '@aziontech/utils': resolve(__dirname, '../utils/src/'),
-    '@aziontech/config': resolve(__dirname, '../config/src/'),
-    '@aziontech/config/rules': resolve(__dirname, '../config/src/rules/'),
-    '@aziontech/presets': resolve(__dirname, '../presets/src/'),
-    '@aziontech/builder': resolve(__dirname, '../builder/src/'),
-    '@aziontech/types': resolve(__dirname, '../types/src/'),
-  },
   external: (id) => {
     if (id.includes('node_modules')) return true;
 
@@ -29,6 +17,9 @@ export default createViteConfig({
       'fs/promises',
       'path',
       'cookie',
+      '@aziontech/unenv-preset',
+      '@aziontech/utils',
+      '@aziontech/config',
     ];
 
     return deps.some((dep) => id === dep || id.startsWith(`${dep}/`));

--- a/packages/presets/vite.config.presets.js
+++ b/packages/presets/vite.config.presets.js
@@ -19,19 +19,6 @@ const getPresetsEntries = () => {
 };
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@aziontech/unenv-preset': resolve(__dirname, '../unenv-preset/src/'),
-      '@aziontech/utils/edge': resolve(__dirname, '../utils/src/edge/'),
-      '@aziontech/utils/node': resolve(__dirname, '../utils/src/node/'),
-      '@aziontech/utils': resolve(__dirname, '../utils/src/'),
-      '@aziontech/config/rules': resolve(__dirname, '../config/src/rules/'),
-      '@aziontech/config': resolve(__dirname, '../config/src/'),
-      '@aziontech/presets': resolve(__dirname, '../presets/src/'),
-      '@aziontech/builder': resolve(__dirname, '../builder/src/'),
-      '@aziontech/types': resolve(__dirname, '../types/src/'),
-    },
-  },
   build: {
     ssr: true,
     emptyOutDir: false,
@@ -54,6 +41,9 @@ export default defineConfig({
           'fs',
           'fs/promises',
           'path',
+          '@aziontech/unenv-preset',
+          '@aziontech/utils',
+          '@aziontech/config',
         ];
 
         return deps.some((dep) => id === dep || id.startsWith(`${dep}/`));

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -27,10 +27,13 @@
     "src/polyfills/*"
   ],
   "dependencies": {
+    "accepts": "^1.3.8",
     "assert-browserify": "^2.0.0",
     "browserify-zlib": "^0.2.0",
     "base64-js": "^1.5.1",
     "crypto-browserify": "^3.12.1",
+    "string_decoder": "^1.3.0",
+    "timers-browserify": "^2.0.12",
     "unenv": "^2.0.0-rc.15",
     "url": "^0.11.4"
   },

--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -23,7 +23,7 @@ export default {
     buffer: `${polyfillsPath}/node/buffer.js`,
     https: `${polyfillsPath}/node/https.js`,
     module: `${polyfillsPath}/node/module.js`,
-    string_decoder: 'string_decoder',
+    string_decoder: 'string_decoder/',
     timers: 'timers-browserify',
     util: `${polyfillsPath}/node/util.js`,
     zlib: `${polyfillsPath}/node/zlib.js`,

--- a/packages/unenv-preset/vite.config.mjs
+++ b/packages/unenv-preset/vite.config.mjs
@@ -3,5 +3,14 @@ import { createViteConfig } from '@aziontech/vite-config';
 export default createViteConfig({
   dirname: __dirname,
   ssr: true,
-  external: ['crypto-browserify'],
+  external: [
+    'crypto-browserify',
+    'assert-browserify',
+    'browserify-zlib',
+    'string_decoder',
+    'unenv',
+    'url',
+    'accepts',
+    'timers-browserify',
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,9 +416,6 @@ importers:
       '@aziontech/config':
         specifier: workspace:*
         version: link:../config
-      '@aziontech/presets':
-        specifier: workspace:*
-        version: 'link:'
       '@aziontech/types':
         specifier: workspace:*
         version: link:../types
@@ -434,6 +431,9 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
+      mime-types:
+        specifier: ^3.0.1
+        version: 3.0.2
       pcre-to-regexp:
         specifier: ^1.1.0
         version: 1.1.0
@@ -539,6 +539,9 @@ importers:
 
   packages/unenv-preset:
     dependencies:
+      accepts:
+        specifier: ^1.3.8
+        version: 1.3.8
       assert-browserify:
         specifier: ^2.0.0
         version: 2.0.0
@@ -551,6 +554,12 @@ importers:
       crypto-browserify:
         specifier: ^3.12.1
         version: 3.12.1
+      string_decoder:
+        specifier: ^1.3.0
+        version: 1.3.0
+      timers-browserify:
+        specifier: ^2.0.12
+        version: 2.0.12
       unenv:
         specifier: ^2.0.0-rc.15
         version: 2.0.0-rc.24


### PR DESCRIPTION
This pull request primarily focuses on simplifying and standardizing the Vite configuration across multiple packages by removing local alias mappings in favor of using workspace dependencies and externalizing shared packages. It also updates and adds several dependencies to improve compatibility and functionality, especially for the `unenv-preset` and `presets` packages. Additionally, minor improvements are made to telemetry handling to increase robustness.

**Vite configuration simplification and dependency management:**

* Removed local alias mappings from multiple `vite.config.mjs` files (`builder`, `client`, `config`, `presets`) to rely more on workspace dependencies and externalized shared packages like `@aziontech/unenv-preset`, `@aziontech/utils`, `@aziontech/config`, and `@aziontech/presets`. This reduces complexity and potential for path resolution errors. [[1]](diffhunk://#diff-28ace2763727f1be77ff8564dac94afdc59fe379b7c4709e21a82b6aecfbbf1dL2-R12) [[2]](diffhunk://#diff-856d026657307535c7af5bd676c6efe157889b4880855bd5cd46686911ce816cL2-L17) [[3]](diffhunk://#diff-c3890c71cd36851aa10ebe740bb87b5d41d125db95b1a8d5b93576f0fd626b20L2) [[4]](diffhunk://#diff-c3890c71cd36851aa10ebe740bb87b5d41d125db95b1a8d5b93576f0fd626b20L11-L15) [[5]](diffhunk://#diff-4198ffd7cb8d7d0c59afc770ece27cb0151d97c0518006fe269962aae6e19544L2-L17) [[6]](diffhunk://#diff-4198ffd7cb8d7d0c59afc770ece27cb0151d97c0518006fe269962aae6e19544R20-R22)
* Updated the list of external dependencies in `vite.config.mjs` files to ensure that shared packages are not bundled, improving build performance and correctness. [[1]](diffhunk://#diff-28ace2763727f1be77ff8564dac94afdc59fe379b7c4709e21a82b6aecfbbf1dL2-R12) [[2]](diffhunk://#diff-4198ffd7cb8d7d0c59afc770ece27cb0151d97c0518006fe269962aae6e19544R20-R22) [[3]](diffhunk://#diff-26f8cd84298af47a9c640e9527f4fa39fb4443b7fb075f8d95ecb44541f7d8b9L6-R15)

**Dependency updates and additions:**

* Added new dependencies to `unenv-preset` (`accepts`, `string_decoder`, `timers-browserify`) and updated the polyfill mapping for `string_decoder` to use the correct entry point. [[1]](diffhunk://#diff-8c2100363c47ddce8d4e10158417b319db8d176821dc202ed0fd4e9ee4c91b18R30-R36) [[2]](diffhunk://#diff-40a0c89863390a48518ad7870d9042ad049b987f88f48b67368e0b4f9570a450L26-R26) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR542-R544) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR557-R562)
* Added `mime-types` as a dependency in `presets` and updated the lockfile accordingly. Also removed a redundant dependency on `@aziontech/presets` from its own `package.json`. [[1]](diffhunk://#diff-3a2a06beb80964a3716e3bb3a921377af71dc01f852fdd20836cce0fe1613a6eL39) [[2]](diffhunk://#diff-3a2a06beb80964a3716e3bb3a921377af71dc01f852fdd20836cce0fe1613a6eR47) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR434-R436)

**Telemetry improvements:**

* Made the `runPhaseWithTelemetry` function more robust by allowing `telemetry`, `telemetryEnabled`, and `outputFormat` to be optional, and using optional chaining to prevent runtime errors if telemetry is undefined. [[1]](diffhunk://#diff-ac1b78e0374165ed725431fc3f192a58da91a75a285e6e6993a8ab300542d1dcL222-R229) [[2]](diffhunk://#diff-ac1b78e0374165ed725431fc3f192a58da91a75a285e6e6993a8ab300542d1dcL243-R250)
* Added a `getConfig()` method to the `TelemetryCollector` class for easier access to its configuration.

**Lockfile maintenance:**

* Updated `pnpm-lock.yaml` to reflect the new and removed dependencies, ensuring consistency with the changes in `package.json` files. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL419-L421) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR434-R436) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR542-R544) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR557-R562)

These changes collectively streamline the build process, improve maintainability, and enhance compatibility across the monorepo.