### PR TITLE
ci: remove node-version input from install-dependencies action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Run linting
         run: pnpm lint

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Setup git for changeset
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 24
 
       - name: Build Azion package
         run: pnpm run compile


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflows by removing the explicit `node-version: 24` parameter from the `Install Dependencies` step. This change simplifies the workflow configuration and allows the shared action to determine the Node.js version.

- Workflow configuration simplification:
  * `.github/workflows/ci.yml`, `.github/workflows/prereleases.yml`, `.github/workflows/release.yml`: Removed the `with: node-version: 24` parameter from the `Install Dependencies` step, delegating Node.js version selection to the shared action. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-L21) [[2]](diffhunk://#diff-d222a98ebbb50d0533a810ea1520cd202df58f31ee3edf09d0e9f407f3ccd08bL24-L25) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L23-L24)