### PR TITLE
ci: fix changeset workflow issues with branch handling and commit message

### DIFF
--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -29,7 +29,10 @@ jobs:
 
           # Create local main branch pointing to origin/main
           # Changeset looks for local "main" branch, not origin/main
-          git branch -f main origin/main
+          # Only force update if main is not the current branch (to avoid worktree error)
+          if [ "$(git branch --show-current)" != "main" ]; then
+            git branch -f main origin/main
+          fi
 
       - name: Detect changed packages
         id: changeset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm exec changeset publish
+          commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NODE_ENV: 'production'


### PR DESCRIPTION
This pull request makes small but important improvements to the GitHub Actions workflows for prereleases and releases, focusing on safety and clarity.

Workflow improvements:

* In `.github/workflows/prereleases.yml`, the script that creates a local `main` branch now only force-updates the branch if `main` is not currently checked out, preventing potential worktree errors.
* In `.github/workflows/release.yml`, the changeset publish action now includes a custom commit message (`chore: version packages`) for versioning commits, improving commit history clarity.