### PR TITLE
chore: reset all package versions to 0.0.0

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/builder",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "This a builder utility for Azion's platform, designed to streamline the development process and enhance productivity.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/bundler-telemetry/package.json
+++ b/packages/bundler-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/bundler-telemetry",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Telemetry system for measuring and reporting build performance in Azion Bundler",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/client",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/config",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Azion configuration.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/presets",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/sql",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/storage",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/types",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Global types for Azion packages",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/unenv-preset",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Azion Unenv preset.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/utils",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This pull request updates the `version` field in the `package.json` files for multiple packages, changing it from `1.0.0` to `0.0.0`. This is likely to indicate a reset or pre-release status for these packages.

**Versioning changes:**

* Set `version` to `0.0.0` in the following packages:
  * `@aziontech/builder` (`packages/builder/package.json`)
  * `@aziontech/bundler-telemetry` (`packages/bundler-telemetry/package.json`)
  * `@aziontech/client` (`packages/client/package.json`)
  * `@aziontech/config` (`packages/config/package.json`)
  * `@aziontech/presets` (`packages/presets/package.json`)
  * `@aziontech/sql` (`packages/sql/package.json`)
  * `@aziontech/storage` (`packages/storage/package.json`)
  * `@aziontech/types` (`packages/types/package.json`)
  * `@aziontech/unenv-preset` (`packages/unenv-preset/package.json`)
  * `@aziontech/utils` (`packages/utils/package.json`)