### PR TITLE
ci(release): use NODE_AUTH_TOKEN for npm authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NODE_ENV: 'production'
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by changing the environment variable name used for the npm authentication token. This improves compatibility with npm's expectations for authentication in CI/CD pipelines.

- In `.github/workflows/release.yml`, replaced the `NPM_TOKEN` environment variable with `NODE_AUTH_TOKEN` for npm authentication.