### PR TITLE
docs(builder): add README documentation

### DIFF
--- a/.changeset/huge-sheep-flash.md
+++ b/.changeset/huge-sheep-flash.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/builder': patch
+---
+
+feat: add readme

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NODE_ENV: 'production'
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} // active when publish a new package

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,0 +1,163 @@
+# Azion Builder
+
+A builder utility for Azion's platform, designed to streamline the development process and enhance productivity by providing build configurations and polyfills for Edge Runtime environments.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Features](#features)
+  - [Bundlers](#bundlers)
+  - [Polyfills](#polyfills)
+- [API Reference](#api-reference)
+- [Contributing](#contributing)
+
+## Installation
+
+Install the package using npm or yarn:
+
+```bash
+npm install @aziontech/builder
+```
+
+or
+
+```bash
+yarn add @aziontech/builder
+```
+
+## Usage
+
+The builder provides utilities to create build configurations for esbuild and webpack, optimized for Azion Edge Runtime.
+
+### Using with esbuild
+
+```javascript
+import { createAzionESBuildConfig, executeESBuildBuild } from '@aziontech/builder';
+
+// Create configuration
+const config = createAzionESBuildConfig({
+  entryPoints: ['./src/index.ts'],
+  outfile: './dist/bundle.js',
+});
+
+// Execute build
+await executeESBuildBuild(config);
+```
+
+### Using with webpack
+
+```javascript
+import { createAzionWebpackConfig, executeWebpackBuild } from '@aziontech/builder';
+
+// Create configuration
+const config = createAzionWebpackConfig({
+  entry: './src/index.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+});
+
+// Execute build
+await executeWebpackBuild(config);
+```
+
+## Features
+
+### Bundlers
+
+The builder supports two bundlers:
+
+- **esbuild** - Fast JavaScript bundler with optimized configuration for Edge Runtime
+- **webpack** - Powerful module bundler with extensive plugin ecosystem
+
+Both bundlers come pre-configured with:
+
+- Node.js polyfills for Edge Runtime compatibility
+- Azion-specific polyfills for platform features
+- Custom Babel loader support
+- Production and development optimizations
+
+### Polyfills
+
+The package includes polyfills for various Node.js modules and Azion-specific features:
+
+- `async-hooks` - Async hooks functionality
+- `crypto` - Cryptographic functions
+- `fs` - File system operations
+- `stream` - Stream handling
+- `promises` - Promise utilities
+- Azion-specific polyfills:
+  - `env-vars` - Environment variables
+  - `fetch` - Fetch API
+  - `fetch-event` - Fetch event handling
+  - `firewall-event` - Firewall event handling
+  - `kv` - Key-value storage
+  - `network-list` - Network list operations
+  - `storage` - Storage API
+
+#### Using Polyfills
+
+```javascript
+// Import polyfills directly
+import '@aziontech/builder/polyfills';
+```
+
+## API Reference
+
+### createAzionESBuildConfig
+
+Creates an esbuild configuration optimized for Azion Edge Runtime.
+
+**Parameters:**
+
+- `options` - esbuild build options
+
+**Returns:**
+
+- `ESBuildConfiguration` - The configured esbuild options
+
+### executeESBuildBuild
+
+Executes the esbuild build process.
+
+**Parameters:**
+
+- `config` - The esbuild configuration
+
+**Returns:**
+
+- `Promise<void>`
+
+### createAzionWebpackConfig
+
+Creates a webpack configuration optimized for Azion Edge Runtime.
+
+**Parameters:**
+
+- `options` - webpack configuration options
+
+**Returns:**
+
+- `WebpackConfiguration` - The configured webpack options
+
+### executeWebpackBuild
+
+Executes the webpack build process.
+
+**Parameters:**
+
+- `config` - The webpack configuration
+
+**Returns:**
+
+- `Promise<void>`
+
+## Contributing
+
+Contributions are welcome! Please read our contributing guidelines for details on our code of conduct and the process for submitting pull requests.
+
+## License
+
+MIT

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -31,7 +31,8 @@
   "files": [
     "dist",
     "package.json",
-    "src/polyfills/*"
+    "src/polyfills/*",
+    "README.md"
   ],
   "dependencies": {
     "@aziontech/config": "workspace:*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,6 +2,7 @@
   "name": "@aziontech/client",
   "version": "0.0.0",
   "description": "",
+  "private": true,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request introduces a patch release for `@aziontech/builder` focused on improving documentation and package configuration. The most significant change is the addition of a comprehensive `README.md` to guide users in installing and using the builder utilities for Azion's platform. There are also minor adjustments to package metadata and workflow comments for clarity.

**Documentation improvements:**

* Added a detailed `README.md` to `packages/builder`, covering installation, usage examples with esbuild and webpack, feature descriptions, polyfill usage, API reference, and contribution guidelines.
* Updated the `files` array in `packages/builder/package.json` to include the new `README.md` in published files.

**Release and workflow adjustments:**

* Added a patch changelog entry for `@aziontech/builder` noting the new README. (.changeset/huge-sheep-flash.md)
* Commented out the `NODE_AUTH_TOKEN` line in `.github/workflows/release.yml` to clarify that it's only needed when publishing a new package.

**Other package metadata:**

* Marked `@aziontech/client` as private in its `package.json` to prevent accidental publishing.