### PR TITLE
ci(release): configure trusted publisher for npm releases

### DIFF
--- a/.changeset/plenty-socks-smoke.md
+++ b/.changeset/plenty-socks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/builder': patch
+---
+
+ci: Trusted Publisher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          node-version: 24
 
       - name: Build Azion package
         run: pnpm run compile
@@ -33,4 +35,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           NODE_ENV: 'production'
-          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} // active when publish a new package

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @aziontech/builder
 
-## 1.0.1
-
-### Patch Changes
-
-- [#430](https://github.com/aziontech/lib/pull/430) [`04aa395`](https://github.com/aziontech/lib/commit/04aa3957f68acd79653e18162b45c22179895201) Thanks [@jcbsfilho](https://github.com/jcbsfilho)! - feat: add readme
-
 ## 1.0.0
 
 ### Major Changes

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/builder",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "This a builder utility for Azion's platform, designed to streamline the development process and enhance productivity.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This pull request introduces a patch release for the `@aziontech/builder` package, primarily focused on CI/CD improvements and release process updates. The main changes include configuring the CI workflow to specify the Node.js version and updating release metadata.

**CI/CD and Release Process Updates:**

* Updated the release workflow to explicitly set the Node.js version to 24 during dependency installation in `.github/workflows/release.yml`.
* Cleaned up the release workflow environment variables, removing a commented-out line related to `NODE_AUTH_TOKEN`.
* Added a changeset file documenting the patch release and referencing the adoption of the Trusted Publisher approach.

**Package Metadata:**

* Reverted the version in `packages/builder/package.json` from `1.0.1` back to `1.0.0`, possibly to correct a versioning inconsistency.
* Removed the unreleased `1.0.1` changelog entry from `packages/builder/CHANGELOG.md`.