### PR TITLE
chore: docs and ci fixes

### DIFF
--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -39,9 +39,19 @@ jobs:
       - name: Detect changed packages
         id: changeset
         run: |
-          pnpm exec changeset status --output /tmp/status.json
+          # Run changeset status, but don't fail if there are no changesets
+          # This allows the workflow to continue gracefully
+          pnpm exec changeset status --output /tmp/status.json || true
 
-          RELEASE_COUNT=$(jq '.releases | length' /tmp/status.json)
+          # Check if the status file was created
+          if [ -f /tmp/status.json ]; then
+            RELEASE_COUNT=$(jq '.releases | length' /tmp/status.json)
+          else
+            # If changeset failed (no changesets found), treat as 0 releases
+            RELEASE_COUNT=0
+            echo '{}' > /tmp/status.json
+          fi
+
           echo "release_count=$RELEASE_COUNT" >> $GITHUB_OUTPUT
           echo "Found $RELEASE_COUNT packages to release"
 

--- a/packages/presets/docs/preset-nuxt.md
+++ b/packages/presets/docs/preset-nuxt.md
@@ -13,7 +13,7 @@ This preset enables Server-Side Rendering (SSR) and Static Site Generation (SSG)
 First, install the Azion package in your Nuxt.js project:
 
 ```bash
-npm install azion
+npm install @aziontech/presets
 ```
 
 ## Configuration SSR

--- a/packages/presets/docs/preset-svelte.md
+++ b/packages/presets/docs/preset-svelte.md
@@ -13,7 +13,7 @@ This preset enables Server-Side Rendering (SSR) and Static Site Generation (SSG)
 First, install the Azion package in your SvelteKit project:
 
 ```bash
-npm install azion
+npm install @aziontech/presets
 ```
 
 ## Configuration SSR


### PR DESCRIPTION
This pull request makes improvements to the release workflow and updates documentation for Nuxt.js and SvelteKit presets. The workflow now handles cases where there are no changesets more gracefully, and the documentation reflects the correct package to install.

Workflow improvements:

* Updated `.github/workflows/prereleases.yml` to ensure the workflow continues without failing when no changesets are found, setting `RELEASE_COUNT` to 0 and creating an empty status file if necessary.

Documentation updates:

* Updated installation instructions in `packages/presets/docs/preset-nuxt.md` to use `@aziontech/presets` instead of `azion`.
* Updated installation instructions in `packages/presets/docs/preset-svelte.md` to use `@aziontech/presets` instead of `azion`.