### PR TITLE
chore: first deployment of the jwt package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,7 +18,6 @@
     "@aziontech/client",
     "@aziontech/cookies",
     "@aziontech/domains",
-    "@aziontech/jwt",
     "@aziontech/purge",
     "@aziontech/router",
     "@aziontech/wasm-image-processor"

--- a/.changeset/tricky-tables-dress.md
+++ b/.changeset/tricky-tables-dress.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/jwt': major
+---
+
+first deployment of the jwt package

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@aziontech/jwt",
   "version": "0.0.0",
-  "private": true,
-  "description": "",
+  "description": "The Azion JWT Library provides utility functions for signing, verifying, and decoding JSON Web Tokens (JWTs).",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request introduces the initial deployment of the `@aziontech/jwt` package, which provides utility functions for signing, verifying, and decoding JSON Web Tokens (JWTs). It also updates the relevant configuration and documentation to reflect the addition of this new package.

New package deployment:

* Added a changeset entry to document the first major deployment of the `@aziontech/jwt` package.
* Updated the `@aziontech/jwt/package.json` file with a descriptive summary of the package and removed the `private` flag to prepare it for public release.

Configuration updates:

* Removed `@aziontech/jwt` from the `.changeset/config.json` package list, likely to enable proper changeset tracking for its initial release.