### PR TITLE
ci: first deployment of the jwt package

### DIFF
--- a/.changeset/cyan-crews-dance.md
+++ b/.changeset/cyan-crews-dance.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/jwt': major
+---
+
+first deployment of the jwt package

--- a/packages/jwt/CHANGELOG.md
+++ b/packages/jwt/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @aziontech/jwt
-
-## 1.0.0
-
-### Major Changes
-
-- [#442](https://github.com/aziontech/lib/pull/442) [`21060d4`](https://github.com/aziontech/lib/commit/21060d41b3bbd7ed39ff5babbcca6a65667722ec) Thanks [@jcbsfilho](https://github.com/jcbsfilho)! - first deployment of the jwt package

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aziontech/jwt",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "The Azion JWT Library provides utility functions for signing, verifying, and decoding JSON Web Tokens (JWTs).",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -35,5 +35,10 @@
     "ts-jest": "^29.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aziontech/lib.git",
+    "directory": "packages/jwt"
   }
 }


### PR DESCRIPTION
This pull request makes initial setup adjustments to the `@aziontech/jwt` package, including updating versioning and repository metadata. It also removes the previous changelog entry for the first deployment.

Packaging and metadata updates:

* Changed the version in `package.json` from `1.0.0` to `0.0.0` to reflect a pre-release or initial development state.
* Added the `repository` field to `package.json` to properly link the package to its GitHub repository and directory.

Changelog and release notes:

* Removed the initial changelog entry from `packages/jwt/CHANGELOG.md` that documented the first deployment of the package.
* Added a new changeset file to record the first deployment of the JWT package.