### PR TITLE
fix(builder): resolve azion polyfills package specifier to filesystem path in esbuild plugin

### DIFF
--- a/.changeset/early-pans-serve.md
+++ b/.changeset/early-pans-serve.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/builder': patch
+---
+
+fix(builder): resolve azion polyfills package specifier to filesystem path in esbuild plugin

--- a/packages/builder/src/bundlers/esbuild/plugins/azion-polyfills/azion-polyfills.ts
+++ b/packages/builder/src/bundlers/esbuild/plugins/azion-polyfills/azion-polyfills.ts
@@ -1,7 +1,10 @@
 import { PluginBuild } from 'esbuild';
 import fs from 'fs';
+import { createRequire } from 'module';
 import path from 'path';
 import azionLibs from '../../../../helpers/azion-local-polyfills';
+
+const requireCustom = createRequire(import.meta.url);
 
 /**
  * ESBuild Azion Module Plugin for polyfilling node modules.
@@ -89,8 +92,10 @@ const ESBuildAzionModulePlugin = (isProduction: boolean) => {
           throw new Error(`Could not resolve module: ${args.path}`);
         }
 
-        const contents = await fs.promises.readFile(resolved, 'utf8');
-        const resolveDir = path.dirname(resolved);
+        // Resolve package exports (e.g., @aziontech/builder/polyfills/...) to a filesystem path
+        const resolvedPath = requireCustom.resolve(resolved);
+        const contents = await fs.promises.readFile(resolvedPath, 'utf8');
+        const resolveDir = path.dirname(resolvedPath);
 
         return {
           loader: 'js',


### PR DESCRIPTION
This pull request addresses an issue with the ESBuild plugin for Azion polyfills by updating how package specifiers are resolved. The main change ensures that references to the `@aziontech/builder/polyfills` package are correctly resolved to their filesystem paths, improving compatibility and reliability during the build process.

**ESBuild Plugin Improvements:**

* Updated the Azion polyfills ESBuild plugin to use Node's `createRequire` for resolving package specifiers to actual filesystem paths, ensuring correct module resolution for polyfills. [[1]](diffhunk://#diff-6dc0b480077eb5c1922a59a195a923e698d103437a5213f4d9438832df5a201fR3-R8) [[2]](diffhunk://#diff-6dc0b480077eb5c1922a59a195a923e698d103437a5213f4d9438832df5a201fL92-R98)
* Added a patch changelog entry documenting the fix for resolving the Azion polyfills package specifier.