### PR TITLE
fix: surface statement-level query errors and fix debug-mode crash

### DIFF
--- a/.changeset/quiet-ways-pick.md
+++ b/.changeset/quiet-ways-pick.md
@@ -1,0 +1,5 @@
+---
+'@aziontech/sql': patch
+---
+
+fix surface statement-level query errors

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -246,6 +246,10 @@ if (result) {
 }
 ```
 
+> **Note:** Statement-level failures reported by the database (for example querying a
+> non-existent table, which returns `no such table: ...`) are surfaced through the
+> `error` field of the response, not thrown. Always check `error` before using `data`.
+
 #### Use Execute
 
 **JavaScript:**
@@ -522,7 +526,7 @@ The response object from a database operation.
 - `columns: string[]`
 - `statement: string`
 - `rows: (number | string)[][]`
-- `error?: string`
+- `error?: string` — set when the individual statement fails (e.g. `no such table: ...`). When present, the operation also resolves with a top-level `error` object.
 
 ### `AzionClientOptions`
 

--- a/packages/sql/src/index.test.ts
+++ b/packages/sql/src/index.test.ts
@@ -448,21 +448,12 @@ describe('SQL Module', () => {
         useQuery('test-db', ['pragma table_list', 'select * from main'], {
           debug: mockDebug,
         }),
-      ).resolves.toEqual(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            state: 'executed',
-            results: expect.arrayContaining([
-              expect.anything(),
-              expect.objectContaining({ error: 'no such table: main' }),
-            ]),
-          }),
-          error: expect.objectContaining({
-            message: 'no such table: main',
-            operation: 'apiQuery',
-          }),
+      ).resolves.toEqual({
+        error: expect.objectContaining({
+          message: 'no such table: main',
+          operation: 'apiQuery',
         }),
-      );
+      });
     });
 
     it('should return error if useQuery when last statement is invalid', async () => {
@@ -526,18 +517,12 @@ describe('SQL Module', () => {
         useQuery('test-db', ['pragma table_list', 'select * from sqlite_schema', 'select * from main'], {
           debug: mockDebug,
         }),
-      ).resolves.toEqual(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            state: 'executed',
-            results: expect.arrayContaining([
-              expect.anything(),
-              expect.anything(),
-              expect.objectContaining({ error: 'no such table: main' }),
-            ]),
-          }),
+      ).resolves.toEqual({
+        error: expect.objectContaining({
+          message: 'no such table: main',
+          operation: 'apiQuery',
         }),
-      );
+      });
     });
 
     it('should return error if useQuery when data rows is empty', async () => {

--- a/packages/sql/src/services/api/index.ts
+++ b/packages/sql/src/services/api/index.ts
@@ -184,18 +184,35 @@ const postQueryDatabase = async (
       };
     }
 
+    // The SQL API reports per-statement failures inside the `data` array
+    // (e.g. `{ error: 'no such table: ...' }`) rather than in `result.errors`.
+    const statementError = Array.isArray(result.data)
+      ? result.data.find((statement: any) => statement && statement.error)
+      : undefined;
+
+    if (statementError) {
+      return {
+        error: { message: statementError.error, operation: 'post query' },
+      };
+    }
+
     const dataResult = result.data;
 
     if (debug) {
       const limitedData: ApiQueryExecutionResponse = {
         ...result,
-        data: (result as ApiQueryExecutionResponse)?.data?.map((data) => ({
-          ...data,
-          results: {
-            ...data.results,
-            rows: limitArraySize(data.results?.rows, 10),
-          },
-        })),
+        data: (result as ApiQueryExecutionResponse)?.data?.map((data) => {
+          if (!data || !data.results) {
+            return data;
+          }
+          return {
+            ...data,
+            results: {
+              ...data.results,
+              rows: limitArraySize(data.results?.rows, 10),
+            },
+          };
+        }),
       };
       console.log('Response Query:', JSON.stringify(limitedData));
     }


### PR DESCRIPTION
## What

Hardens error handling in the SQL package's `postQueryDatabase`:

1. **Fixes a crash in debug mode.** When the SQL API returned a per-statement
   result array containing a `null` entry (e.g. `[{ error: 'no such table: ...' }, null]`),
   the debug `.map()` accessed `.results` on `null` and threw
   `Cannot read properties of null (reading 'results')`.

2. **Surfaces statement-level errors.** The API reports per-statement failures
   *inside* the `data` array rather than in top-level `result.errors`. These are
   now detected and returned as a proper `error` object, instead of being buried
   in the response data.

3. **Updates docs** to make the "check `error` before `data`" behavior explicit.

## Problem Reproduction

Running a query (in localhost - nodejs server) against a non-existent table with debug true produced:
```
[TypeError: Cannot read properties of null (reading 'results')]
```

instead of a clean error response.
