### PR TITLE
fix: restore conventional-changelog-conventionalcommits devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/lodash": "^4.17.20",
         "@types/lodash-es": "^4.17.12",
         "@types/signale": "^1.4.7",
+        "conventional-changelog-conventionalcommits": "^4.6.0",
         "eslint": "^9.36.0",
         "globals": "^16.4.0",
         "husky": "^9.1.7",
@@ -6646,6 +6647,21 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/conventional-changelog-writer": {
@@ -13288,6 +13304,18 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
+    "conventional-changelog-conventionalcommits": "^4.6.0",
     "@types/eslint__js": "^8.42.3",
     "@types/lodash": "^4.17.20",
     "@types/lodash-es": "^4.17.12",


### PR DESCRIPTION
This pull request makes a small update to the project's dependencies by adding the `conventional-changelog-conventionalcommits` package to `package.json` to support standardized changelog generation.